### PR TITLE
Deeplink: add livestreams tab

### DIFF
--- a/src/main/resources/deeplink/v1/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v1/parsePlayUrl.js
@@ -3,10 +3,10 @@
 var parsePlayUrlVersion = 35;
 var parsePlayUrlBuild = "mmf";
 
-if (! console) {
-    var console = {
-        log:function(){}
-    }
+if (!console) {
+	var console = {
+		log: function () { }
+	}
 }
 
 function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
@@ -52,7 +52,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 			break;
 	}
 
-	if (! bu) {
+	if (!bu) {
 		console.log("This URL is not a Play SRG URL.");
 		return null;
 	}
@@ -88,7 +88,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 						redirectBu = "swi";
 						break;
 				}
-				var startTime = queryParams["start"];  
+				var startTime = queryParams["start"];
 				return openMediaUrn(server, redirectBu, mediaUrn, startTime);
 			}
 		}
@@ -142,7 +142,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 		return openPage(server, bu, "tv:home", null, null);
 	}
 
-	if (hostname.includes("play-mmf") && ! pathname.startsWith("/mmf/")) {
+	if (hostname.includes("play-mmf") && !pathname.startsWith("/mmf/")) {
 		pathname = pathname.substring(4);
 	}
 
@@ -200,7 +200,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 		}
 	}
 
-	if (! pathname.startsWith("/play")) {
+	if (!pathname.startsWith("/play")) {
 		console.log("No /play path in url.");
 		return null;
 	}
@@ -228,7 +228,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 		if (mediaUrn) {
 			return openMediaUrn(server, bu, mediaUrn, startTime);
 		}
-		else if (mediaId) {	
+		else if (mediaId) {
 			return openMedia(server, bu, mediaType, mediaId, startTime);
 		}
 		else {
@@ -255,7 +255,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	if (mediaType) {
 		var mediaId = pathname.split("/").slice(-1)[0];
 		if (mediaId) {
-			var startTime = queryParams["startTime"]; 
+			var startTime = queryParams["startTime"];
 			return openMedia(server, bu, mediaType, mediaId, startTime);
 		}
 		else {
@@ -270,7 +270,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.rsi.ch/play/tv/redirect/live/rts?id=3608506&title=RTS+1
 	 *  Ex: https://www.rts.ch/play/tv/redirect/live/srf?id=c4927fcf-e1a0-0001-7edd-1ef01d441651&title=SRF+1
 	 */
-	 switch (true) {
+	switch (true) {
 		case pathname.includes("/tv/redirect/live/"):
 			mediaType = "video";
 			break;
@@ -536,7 +536,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 			index = index.toLowerCase();
 			index = (index.length > 1) ? null : index;
 		}
-		var options = new Array( { key: "index", value: index } );
+		var options = new Array({ key: "index", value: index });
 		return openPage(server, bu, "tv:az", null, options);
 	}
 
@@ -552,7 +552,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 			index = index.toLowerCase();
 			index = (index.length > 1) ? null : index;
 		}
-		var options = new Array( { key: "index", value: index } );
+		var options = new Array({ key: "index", value: index });
 		return openPage(server, bu, "radio:az", channelId, options);
 	}
 
@@ -567,13 +567,13 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 			// Returns an ISO format
 			var dateArray = date.split("-");
 			if (dateArray.length == 3 && dateArray[2].length == 4 && dateArray[1].length == 2 && dateArray[0].length == 2) {
-				date = dateArray[2] + "-" + dateArray[1] + "-" + dateArray[0];  
+				date = dateArray[2] + "-" + dateArray[1] + "-" + dateArray[0];
 			}
 			else {
 				date = null;
 			}
 		}
-		var options = new Array( { key: "date", value: date } );
+		var options = new Array({ key: "date", value: date });
 		return openPage(server, bu, "tv:bydate", null, options);
 	}
 
@@ -584,7 +584,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.srf.ch/play/tv/programm/2021-07-03
 	 */
 	if (pathname.includes("/tv/sendungen-nach-datum") || pathname.includes("/tv/emissions-par-dates") || pathname.includes("/tv/programmi-per-data") || pathname.includes("/tv/emissiuns-tenor-data") ||
-	pathname.includes("/tv/programm") || pathname.includes("/tv/programme") || pathname.includes("/tv/guida-programmi") || pathname.includes("/tv/program")) {
+		pathname.includes("/tv/programm") || pathname.includes("/tv/programme") || pathname.includes("/tv/guida-programmi") || pathname.includes("/tv/program")) {
 		var lastPathComponent = pathname.split("/").slice(-1)[0];
 
 		var date = null;
@@ -595,7 +595,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 				date = lastPathComponent;
 			}
 		}
-		var options = new Array( { key: "date", value: date } );
+		var options = new Array({ key: "date", value: date });
 		return openPage(server, bu, "tv:bydate", null, options);
 	}
 
@@ -611,13 +611,13 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 			// Returns an ISO format
 			var dateArray = date.split("-");
 			if (dateArray.length == 3 && dateArray[2].length == 4 && dateArray[1].length == 2 && dateArray[0].length == 2) {
-				date = dateArray[2] + "-" + dateArray[1] + "-" + dateArray[0];  
+				date = dateArray[2] + "-" + dateArray[1] + "-" + dateArray[0];
 			}
 			else {
 				date = null;
 			}
 		}
-		var options = new Array( { key: "date", value: date } );
+		var options = new Array({ key: "date", value: date });
 		return openPage(server, bu, "radio:bydate", channelId, options);
 	}
 
@@ -638,7 +638,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 			}
 		}
 		var transmissionComponent = (transmission != null) ? transmission + ":" : "";
-		var options = new Array( { key: "query", value: query }, { key: "mediaType", value: mediaType } );
+		var options = new Array({ key: "query", value: query }, { key: "mediaType", value: mediaType });
 		return openPage(server, bu, transmissionComponent + "search", null, options);
 	}
 
@@ -651,7 +651,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 		return openPage(server, bu, "tv:home", null, null);
 	}
 	else if (pathname.includes("/tv/themen") || pathname.includes("/tv/categories") || pathname.includes("/tv/categorie") || pathname.includes("/tv/tematicas") || pathname.includes("/tv/topics")) {
-		var lastPathComponent = pathname.split("/").slice(-1)[0]; 
+		var lastPathComponent = pathname.split("/").slice(-1)[0];
 
 		var topicId = null;
 
@@ -685,7 +685,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.rts.ch/play/tv/detail/bulles-dair?id=f75179d9-f621-4855-b695-a9ba206864c2
 	 *  Ex: https://www.rsi.ch/play/tv/detail/il-giardino-di-albert-lis?id=bd8d8352-4512-4f24-86b0-c380f94ab701
 	 */
-	 if (pathname.endsWith("/tv/detail")) {
+	if (pathname.endsWith("/tv/detail")) {
 		return openPage(server, bu, "tv:home", null, null);
 	}
 	else if (pathname.includes("/tv/detail")) {
@@ -705,7 +705,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.srf.ch/play/
 	 *  Ex: https://www.rsi.ch/play
 	 */
-	 if (pathname.endsWith("/play/") || pathname.endsWith("/play")) {
+	if (pathname.endsWith("/play/") || pathname.endsWith("/play")) {
 		return openPage(server, bu, "tv:home", null, null);
 	}
 
@@ -725,7 +725,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.srf.ch/play/sitemap/tv/pages
 	 *. Ex: https://www.rts.ch/play/sitemap/tv/pages
 	 */
-	 if (pathname.includes("/play/sitemap/")) {
+	if (pathname.includes("/play/sitemap/")) {
 		return openPage(server, bu, "tv:home", null, null);
 	}
 
@@ -818,22 +818,22 @@ function openSection(server, bu, sectionId) {
 }
 
 function openPage(server, bu, page, channelId, options) {
-	if (! page) {
+	if (!page) {
 		page = "tv:home";
 	}
 
 	var pageUid = page.split(":").slice(-1)[0];
 
-	if (page.startsWith("radio:") && ! channelId) {
+	if (page.startsWith("radio:") && !channelId) {
 		channelId = primaryChannelUidForBu(bu);
 	}
-	
+
 	var redirect = schemeForBu(bu) + "://open?page=urn:" + bu + ":page:" + page + "&page-id=" + pageUid;
 	if (channelId) {
 		redirect = redirect + "&channel-id=" + channelId;
 	}
 	if (options && Array.isArray(options)) {
-		options.forEach(function(option) {
+		options.forEach(function (option) {
 			if (option.key && option.value) {
 				redirect = redirect + "&" + option.key + "=" + encodeURIComponent(option.value);
 			}
@@ -846,7 +846,7 @@ function openPage(server, bu, page, channelId, options) {
 }
 
 function openURL(server, bu, scheme, hostname, pathname, queryParams, anchor) {
-	if (! scheme) {
+	if (!scheme) {
 		scheme = "http";
 	}
 
@@ -857,7 +857,7 @@ function openURL(server, bu, scheme, hostname, pathname, queryParams, anchor) {
 		}
 	}
 	if (queryParamsString.length > 0) {
-		queryParamsString = queryParamsString.replace('&','?');
+		queryParamsString = queryParamsString.replace('&', '?');
 	}
 
 	var anchorString = "";
@@ -974,8 +974,8 @@ function serverForUrl(hostname, pathname, queryParams) {
 }
 
 function getBuFromPathname(pathname) {
-    switch (true) {
-    	case pathname.endsWith("rsi"):
+	switch (true) {
+		case pathname.endsWith("rsi"):
 			return "rsi";
 		case pathname.endsWith("rtr"):
 			return "rtr";
@@ -987,4 +987,4 @@ function getBuFromPathname(pathname) {
 			return "swi";
 	}
 	return null;
- }
+}

--- a/src/main/resources/deeplink/v1/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v1/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 34;
+var parsePlayUrlVersion = 35;
 var parsePlayUrlBuild = "mmf";
 
 if (! console) {
@@ -323,8 +323,8 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 			return openMedia(server, bu, "video", mediaId, null);
 		}
 		else {
-			// Returns default TV homepage
-			return openPage(server, bu, "tv:home", null, null);
+			// Returns livestreams homepage
+			return openPage(server, bu, "livestreams", null, null);
 		}
 	}
 
@@ -336,31 +336,8 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.rsi.ch/play/radio/legacy-livepopup/rete-uno
 	 */
 	if (pathname.endsWith("/radio/livepopup") || pathname.endsWith("/radio/legacy-livepopup") || pathname.endsWith("/radio/livepopup/") || pathname.endsWith("/radio/legacy-livepopup/")) {
-		var mediaId = null;
-
-		switch (bu) {
-			case "srf":
-				mediaId = "69e8ac16-4327-4af4-b873-fd5cd6e895a7";
-				break;
-			case "rts":
-				mediaId = "3262320";
-				break;
-			case "rsi":
-				mediaId = "livestream_ReteUno";
-				break;
-			case "rtr":
-				mediaId = "a029e818-77a5-4c2e-ad70-d573bb865e31";
-				break;
-			default:
-		}
-
-		if (mediaId) {
-			return openMedia(server, bu, "audio", mediaId, null);
-		}
-		else {
-			// Returns default radio homepage
-			return openPage(server, bu, "radio:home", null, null);
-		}
+		// Returns livestreams homepage
+		return openPage(server, bu, "livestreams", null, null);
 	}
 	else if (pathname.includes("/radio/livepopup/") || pathname.includes("/radio/legacy-livepopup/")) {
 		var mediaBu = null;
@@ -428,8 +405,8 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 			return openMedia(server, mediaBu, "audio", mediaId, null);
 		}
 		else {
-			// Returns default radio homepage
-			return openPage(server, bu, "radio:home", null, null);
+			// Returns livestreams homepage
+			return openPage(server, bu, "livestreams", null, null);
 		}
 	}
 
@@ -463,6 +440,18 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 			// Returns default TV homepage
 			return openPage(server, bu, "radio:home", null, null);
 		}
+	}
+
+	/**
+	 *  Catch BU livestreams urls
+	 *
+	 *  Ex: https://www.rtr.ch/play/tv/rtr-livestreams
+	 *  Ex: https://www.rts.ch/play/tv/rts-livestreams
+	 *  Ex: https://www.srf.ch/play/tv/sport-livestreams
+	 */
+	if (pathname.endsWith("-livestreams")) {
+		// Returns livestreams homepage
+		return openPage(server, bu, "livestreams", null, null);
 	}
 
 	/**

--- a/src/main/resources/deeplink/v2/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v2/parsePlayUrl.js
@@ -744,7 +744,7 @@ function openMediaUrn(server, bu, mediaUrn, startTime) {
 	if (server) {
 	    options['server'] = server;
 	}
-    return buildBuUri(bu,"media",mediaUrn,options);
+    return buildBuUri(bu, "media", mediaUrn, options);
 }
 
 function openShow(server, bu, showTransmission, showId) {
@@ -753,7 +753,7 @@ function openShow(server, bu, showTransmission, showId) {
 	if (server) {
 	    options['server'] = server;
 	}
-    return buildBuUri(bu,"show",showUrn,options);
+    return buildBuUri(bu, "show", showUrn, options);
 }
 
 function openTopic(server, bu, topicTransmission, topicId) {
@@ -762,7 +762,7 @@ function openTopic(server, bu, topicTransmission, topicId) {
 	if (server) {
 	    options['server'] = server;
 	}
-    return buildBuUri(bu,"topic",topicUrn,options);
+    return buildBuUri(bu, "topic", topicUrn, options);
 }
 
 function openModule(server, bu, moduleType, moduleId) {
@@ -771,7 +771,7 @@ function openModule(server, bu, moduleType, moduleId) {
 	if (server) {
 	    options['server'] = server;
 	}
-    return buildBuUri(bu,"module",topicUrn,options);
+    return buildBuUri(bu, "module", topicUrn, options);
 }
 
 function openSection(server, bu, sectionId) {
@@ -779,7 +779,7 @@ function openSection(server, bu, sectionId) {
 	if (server) {
 	    options['server'] = server;
 	}
-    return buildBuUri(bu,"section",sectionId,options);
+    return buildBuUri(bu, "section", sectionId, options);
 }
 
 function openTvHomePage(server,bu){
@@ -787,7 +787,7 @@ function openTvHomePage(server,bu){
     if (server) {
         options['server'] = server;
     }
-    return buildBuUri(bu,"home",null,options);
+    return buildBuUri(bu, "home", null, options);
 }
 
 function openLivestreamsHomePage(server,bu){
@@ -795,7 +795,7 @@ function openLivestreamsHomePage(server,bu){
     if (server) {
         options['server'] = server;
     }
-    return buildBuUri(bu,"livestreams",null,options);
+    return buildBuUri(bu, "livestreams", null, options);
 }
 
 function openRadioHomePage(server,bu,channelId){
@@ -809,7 +809,7 @@ function openRadioHomePage(server,bu,channelId){
     if (server) {
         options['server'] = server;
     }
-    return buildBuUri(bu,"home",null,options);
+    return buildBuUri(bu, "home", null, options);
 }
 
 function openAtoZ(server,bu,channelId,index){
@@ -823,7 +823,7 @@ function openAtoZ(server,bu,channelId,index){
    if (server) {
         options['server'] = server;
    }
-   return buildBuUri(bu,"az",null,options);
+   return buildBuUri(bu, "az", null, options);
 }
 
 function openRadioAtoZ(server,bu,channelId,index){
@@ -833,7 +833,7 @@ function openRadioAtoZ(server,bu,channelId,index){
     return openAtoZ(server,bu,channelId,index);
 }
 
-function openByDate(server,bu,channelId,date){
+function openByDate(server, bu, channelId, date){
     var options = {};
     if (channelId) {
         options['channel_id'] = channelId;
@@ -848,7 +848,7 @@ function openByDate(server,bu,channelId,date){
     return buildBuUri(bu, "bydate", null, options);
 }
 
-function openRadioByDate(server,bu,channelId,date) {
+function openRadioByDate(server, bu, channelId, date) {
     if (!channelId) {
         channelId = primaryChannelUidForBu(bu);
     }
@@ -895,7 +895,7 @@ function openURL(server, bu, scheme, hostname, pathname, queryParams, anchor) {
     if (server) {
         options['server'] = server;
     }
-    return buildBuUri(bu,"link",null,options)
+    return buildBuUri(bu, "link", null, options)
 }
 
 // --- parsing functions

--- a/src/main/resources/deeplink/v2/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v2/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 34;
+var parsePlayUrlVersion = 35;
 var parsePlayUrlBuild = "mmf";
 
 if (! console) {
@@ -296,8 +296,8 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 			return openMedia(server, bu, "video", mediaId, null);
 		}
 		else {
-			// Returns default TV homepage
-			return openTvHomePage(server, bu);
+			// Returns livestreams homepage
+			return openLivestreamsHomePage(server, bu);
 		}
 	}
 
@@ -309,31 +309,8 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.rsi.ch/play/radio/legacy-livepopup/rete-uno
 	 */
 	if (pathname.endsWith("/radio/livepopup") || pathname.endsWith("/radio/legacy-livepopup") || pathname.endsWith("/radio/livepopup/") || pathname.endsWith("/radio/legacy-livepopup/")) {
-		var mediaId = null;
-
-		switch (bu) {
-			case "srf":
-				mediaId = "69e8ac16-4327-4af4-b873-fd5cd6e895a7";
-				break;
-			case "rts":
-				mediaId = "3262320";
-				break;
-			case "rsi":
-				mediaId = "livestream_ReteUno";
-				break;
-			case "rtr":
-				mediaId = "a029e818-77a5-4c2e-ad70-d573bb865e31";
-				break;
-			default:
-		}
-
-		if (mediaId) {
-			return openMedia(server, bu, "audio", mediaId, null);
-		}
-		else {
-			// Returns default radio homepage
-			return openRadioHomePage(server, bu, null);
-		}
+		// Returns livestreams homepage
+		return openLivestreamsHomePage(server, bu);
 	}
 	else if (pathname.includes("/radio/livepopup/") || pathname.includes("/radio/legacy-livepopup/")) {
 		var mediaBu = null;
@@ -401,8 +378,8 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 			return openMedia(server, mediaBu, "audio", mediaId, null);
 		}
 		else {
-			// Returns default radio homepage
-			return openRadioHomePage(server, bu, null);
+			// Returns livestreams homepage
+			return openLivestreamsHomePage(server, bu);
 		}
 	}
 
@@ -436,6 +413,18 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 			// Returns default radio homepage
 			return openRadioHomePage(server, bu, null);
 		}
+	}
+
+	/**
+	 *  Catch BU livestreams urls
+	 *
+	 *  Ex: https://www.rtr.ch/play/tv/rtr-livestreams
+	 *  Ex: https://www.rts.ch/play/tv/rts-livestreams
+	 *  Ex: https://www.srf.ch/play/tv/sport-livestreams
+	 */
+	if (pathname.endsWith("-livestreams")) {
+		// Returns livestreams homepage
+		return openLivestreamsHomePage(server, bu);
 	}
 
 	/**
@@ -799,6 +788,14 @@ function openTvHomePage(server,bu){
         options['server'] = server;
     }
     return buildBuUri(bu,"home",null,options);
+}
+
+function openLivestreamsHomePage(server,bu){
+    var options = {};
+    if (server) {
+        options['server'] = server;
+    }
+    return buildBuUri(bu,"livestreams",null,options);
 }
 
 function openRadioHomePage(server,bu,channelId){

--- a/src/main/resources/deeplink/v2/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v2/parsePlayUrl.js
@@ -3,10 +3,10 @@
 var parsePlayUrlVersion = 35;
 var parsePlayUrlBuild = "mmf";
 
-if (! console) {
-    var console = {
-        log:function(){}
-    }
+if (!console) {
+	var console = {
+		log: function () { }
+	}
 }
 
 function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
@@ -24,8 +24,8 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	pathname = pathname.toLowerCase();
 
 	// Get BU
-	var bu = getBuFromHostname(hostname,pathname);
-	if (! bu) {
+	var bu = getBuFromHostname(hostname, pathname);
+	if (!bu) {
 		console.log("This URL is not a Play SRG URL.");
 		return null;
 	}
@@ -115,7 +115,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 		return openTvHomePage(server, bu);
 	}
 
-	if (hostname.includes("play-mmf") && ! pathname.startsWith("/mmf/")) {
+	if (hostname.includes("play-mmf") && !pathname.startsWith("/mmf/")) {
 		pathname = pathname.substring(4);
 	}
 
@@ -173,7 +173,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 		}
 	}
 
-	if (! pathname.startsWith("/play")) {
+	if (!pathname.startsWith("/play")) {
 		console.log("No /play path in url.");
 		return null;
 	}
@@ -201,7 +201,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 		if (mediaUrn) {
 			return openMediaUrn(server, bu, mediaUrn, startTime);
 		}
-		else if (mediaId) {	
+		else if (mediaId) {
 			return openMedia(server, bu, mediaType, mediaId, startTime);
 		}
 		else {
@@ -243,7 +243,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.rsi.ch/play/tv/redirect/live/rts?id=3608506&title=RTS+1
 	 *  Ex: https://www.rts.ch/play/tv/redirect/live/srf?id=c4927fcf-e1a0-0001-7edd-1ef01d441651&title=SRF+1
 	 */
-	 switch (true) {
+	switch (true) {
 		case pathname.includes("/tv/redirect/live/"):
 			mediaType = "video";
 			break;
@@ -554,7 +554,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.srf.ch/play/tv/programm/2021-07-03
 	 */
 	if (pathname.includes("/tv/sendungen-nach-datum") || pathname.includes("/tv/emissions-par-dates") || pathname.includes("/tv/programmi-per-data") || pathname.includes("/tv/emissiuns-tenor-data") ||
-	pathname.includes("/tv/programm") || pathname.includes("/tv/programme") || pathname.includes("/tv/guida-programmi") || pathname.includes("/tv/program")) {
+		pathname.includes("/tv/programm") || pathname.includes("/tv/programme") || pathname.includes("/tv/guida-programmi") || pathname.includes("/tv/program")) {
 		var lastPathComponent = pathname.split("/").slice(-1)[0];
 
 		var date = null;
@@ -670,7 +670,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.srf.ch/play/
 	 *  Ex: https://www.rsi.ch/play
 	 */
-	 if (pathname.endsWith("/play/") || pathname.endsWith("/play")) {
+	if (pathname.endsWith("/play/") || pathname.endsWith("/play")) {
 		return openTvHomePage(server, bu);
 	}
 
@@ -690,7 +690,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.srf.ch/play/sitemap/tv/pages
 	 *. Ex: https://www.rts.ch/play/sitemap/tv/pages
 	 */
-	 if (pathname.includes("/play/sitemap/")) {
+	if (pathname.includes("/play/sitemap/")) {
 		return openTvHomePage(server, bu);
 	}
 
@@ -732,145 +732,145 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 // ---- Open functions
 
 function openMedia(server, bu, mediaType, mediaId, startTime) {
-    var urn = "urn:" + bu + ":" + mediaType + ":" + mediaId;
-    return openMediaUrn(server, bu, urn, startTime);
+	var urn = "urn:" + bu + ":" + mediaType + ":" + mediaId;
+	return openMediaUrn(server, bu, urn, startTime);
 }
 
 function openMediaUrn(server, bu, mediaUrn, startTime) {
 	var options = {};
 	if (startTime) {
-	    options['start_time'] = startTime;
+		options['start_time'] = startTime;
 	}
 	if (server) {
-	    options['server'] = server;
+		options['server'] = server;
 	}
-    return buildBuUri(bu, "media", mediaUrn, options);
+	return buildBuUri(bu, "media", mediaUrn, options);
 }
 
 function openShow(server, bu, showTransmission, showId) {
-    var showUrn = "urn:" + bu + ":show:" + showTransmission + ":" + showId;
-    var options = {};
+	var showUrn = "urn:" + bu + ":show:" + showTransmission + ":" + showId;
+	var options = {};
 	if (server) {
-	    options['server'] = server;
+		options['server'] = server;
 	}
-    return buildBuUri(bu, "show", showUrn, options);
+	return buildBuUri(bu, "show", showUrn, options);
 }
 
 function openTopic(server, bu, topicTransmission, topicId) {
-    var topicUrn = "urn:" + bu + ":topic:" + topicTransmission + ":" + topicId;
-    var options = {};
+	var topicUrn = "urn:" + bu + ":topic:" + topicTransmission + ":" + topicId;
+	var options = {};
 	if (server) {
-	    options['server'] = server;
+		options['server'] = server;
 	}
-    return buildBuUri(bu, "topic", topicUrn, options);
+	return buildBuUri(bu, "topic", topicUrn, options);
 }
 
 function openModule(server, bu, moduleType, moduleId) {
-    var topicUrn = "urn:" + bu + ":module:" + moduleType + ":" + moduleId;
-    var options = {};
+	var topicUrn = "urn:" + bu + ":module:" + moduleType + ":" + moduleId;
+	var options = {};
 	if (server) {
-	    options['server'] = server;
+		options['server'] = server;
 	}
-    return buildBuUri(bu, "module", topicUrn, options);
+	return buildBuUri(bu, "module", topicUrn, options);
 }
 
 function openSection(server, bu, sectionId) {
-    var options = {};
+	var options = {};
 	if (server) {
-	    options['server'] = server;
+		options['server'] = server;
 	}
-    return buildBuUri(bu, "section", sectionId, options);
+	return buildBuUri(bu, "section", sectionId, options);
 }
 
-function openTvHomePage(server,bu){
-    var options = {};
-    if (server) {
-        options['server'] = server;
-    }
-    return buildBuUri(bu, "home", null, options);
+function openTvHomePage(server, bu) {
+	var options = {};
+	if (server) {
+		options['server'] = server;
+	}
+	return buildBuUri(bu, "home", null, options);
 }
 
-function openLivestreamsHomePage(server,bu){
-    var options = {};
-    if (server) {
-        options['server'] = server;
-    }
-    return buildBuUri(bu, "livestreams", null, options);
+function openLivestreamsHomePage(server, bu) {
+	var options = {};
+	if (server) {
+		options['server'] = server;
+	}
+	return buildBuUri(bu, "livestreams", null, options);
 }
 
-function openRadioHomePage(server,bu,channelId){
-    if (!channelId) {
-        channelId = primaryChannelUidForBu(bu);
-    }
-    var options = {};
-    if (channelId) {
-        options["channel_id"] = channelId;
-    }
-    if (server) {
-        options['server'] = server;
-    }
-    return buildBuUri(bu, "home", null, options);
+function openRadioHomePage(server, bu, channelId) {
+	if (!channelId) {
+		channelId = primaryChannelUidForBu(bu);
+	}
+	var options = {};
+	if (channelId) {
+		options["channel_id"] = channelId;
+	}
+	if (server) {
+		options['server'] = server;
+	}
+	return buildBuUri(bu, "home", null, options);
 }
 
-function openAtoZ(server,bu,channelId,index){
-   var options = {};
-   if (channelId) {
-       options['channel_id'] = channelId;
-   }
-   if (index) {
-        options['index'] = index;
-   }
-   if (server) {
-        options['server'] = server;
-   }
-   return buildBuUri(bu, "az", null, options);
+function openAtoZ(server, bu, channelId, index) {
+	var options = {};
+	if (channelId) {
+		options['channel_id'] = channelId;
+	}
+	if (index) {
+		options['index'] = index;
+	}
+	if (server) {
+		options['server'] = server;
+	}
+	return buildBuUri(bu, "az", null, options);
 }
 
-function openRadioAtoZ(server,bu,channelId,index){
-    if (!channelId) {
-    	channelId = primaryChannelUidForBu(bu);
-    }
-    return openAtoZ(server,bu,channelId,index);
+function openRadioAtoZ(server, bu, channelId, index) {
+	if (!channelId) {
+		channelId = primaryChannelUidForBu(bu);
+	}
+	return openAtoZ(server, bu, channelId, index);
 }
 
-function openByDate(server, bu, channelId, date){
-    var options = {};
-    if (channelId) {
-        options['channel_id'] = channelId;
-    }
+function openByDate(server, bu, channelId, date) {
+	var options = {};
+	if (channelId) {
+		options['channel_id'] = channelId;
+	}
 
-    if (date) {
-            options['date'] = date;
-        }
-    if (server) {
-        options['server'] = server;
-    }
-    return buildBuUri(bu, "bydate", null, options);
+	if (date) {
+		options['date'] = date;
+	}
+	if (server) {
+		options['server'] = server;
+	}
+	return buildBuUri(bu, "bydate", null, options);
 }
 
 function openRadioByDate(server, bu, channelId, date) {
-    if (!channelId) {
-        channelId = primaryChannelUidForBu(bu);
-    }
-    return openByDate(server,bu,channelId,date);
+	if (!channelId) {
+		channelId = primaryChannelUidForBu(bu);
+	}
+	return openByDate(server, bu, channelId, date);
 }
 
-function openSearch(server, bu, query, mediaType){
-    var options = {};
-    if (query) {
-        options['query'] = query;
-    }
-    if (mediaType) {
-        options['media_type'] = mediaType;
-    }
-    if (server) {
-        options['server'] = server;
-    }
-    return buildBuUri(bu,"search", null, options);
+function openSearch(server, bu, query, mediaType) {
+	var options = {};
+	if (query) {
+		options['query'] = query;
+	}
+	if (mediaType) {
+		options['media_type'] = mediaType;
+	}
+	if (server) {
+		options['server'] = server;
+	}
+	return buildBuUri(bu, "search", null, options);
 }
 
 function openURL(server, bu, scheme, hostname, pathname, queryParams, anchor) {
-	if (! scheme) {
+	if (!scheme) {
 		scheme = "http";
 	}
 
@@ -881,7 +881,7 @@ function openURL(server, bu, scheme, hostname, pathname, queryParams, anchor) {
 		}
 	}
 	if (queryParamsString.length > 0) {
-		queryParamsString = queryParamsString.replace('&','?');
+		queryParamsString = queryParamsString.replace('&', '?');
 	}
 
 	var anchorString = "";
@@ -890,12 +890,12 @@ function openURL(server, bu, scheme, hostname, pathname, queryParams, anchor) {
 	}
 
 	var url = scheme + "://" + hostname + pathname + queryParamsString + anchorString;
-    var options = {};
-    options['url'] = url;
-    if (server) {
-        options['server'] = server;
-    }
-    return buildBuUri(bu, "link", null, options)
+	var options = {};
+	options['url'] = url;
+	if (server) {
+		options['server'] = server;
+	}
+	return buildBuUri(bu, "link", null, options)
 }
 
 // --- parsing functions
@@ -1000,30 +1000,30 @@ function serverForUrl(hostname, pathname, queryParams) {
 }
 
 function getBuFromHostname(hostname, pathname) {
-    switch (true) {
-    	case hostname.endsWith("tp.srgssr.ch") || hostname.endsWith("player.rts.ch") || hostname.endsWith("player.rsi.ch") || hostname.endsWith("player.rtr.ch") || hostname.endsWith("player.swissinfo.ch") || hostname.endsWith("player.srf.ch") || (hostname.includes("srgssr") && pathname.startsWith("/srgletterbox-web")):
-    		return "lb";
-    	case (hostname.includes("rts.ch") && !hostname.includes("play-staging")) || hostname.includes("srgplayer-rts") || (hostname.includes("play-mmf") && pathname.startsWith("/rts/")) || ((hostname.includes("play-web") || hostname.includes("play-staging")) && pathname.startsWith("/rts/")):
-    		return  "rts";
-    	case hostname.includes("rsi.ch") || hostname.includes("srgplayer-rsi") || (hostname.includes("play-mmf") && pathname.startsWith("/rsi/")) || ((hostname.includes("play-web") || hostname.includes("play-staging")) && pathname.startsWith("/rsi/")):
-    		return  "rsi";
-    	case hostname.includes("rtr.ch") || hostname.includes("srgplayer-rtr") || (hostname.includes("play-mmf") && pathname.startsWith("/rtr/")) || ((hostname.includes("play-web") || hostname.includes("play-staging")) && pathname.startsWith("/rtr/")):
-    		return "rtr";
-    	case hostname.includes("swissinfo.ch") || hostname.includes("srgplayer-swi") || (hostname.includes("play-mmf") && pathname.startsWith("/swi/")) || ((hostname.includes("play-web") || hostname.includes("play-staging")) && pathname.startsWith("/swi/")):
-    		return "swi";
-    	case hostname.includes("srf.ch") || hostname.includes("srgplayer-srf") || (hostname.includes("play-mmf") && pathname.startsWith("/srf/")) || ((hostname.includes("play-web") || hostname.includes("play-staging")) && pathname.startsWith("/srf/")):
-    		return "srf";
-    	case hostname.includes("play-mmf") && pathname.startsWith("/mmf/"):
-    		return "mmf";
-    	case hostname.includes("radioswisspop.ch") || hostname.includes("radioswissclassic.ch") || hostname.includes("radioswissjazz.ch"):
-    		  return "radioswiss";
-    }
-    return null;
- }
+	switch (true) {
+		case hostname.endsWith("tp.srgssr.ch") || hostname.endsWith("player.rts.ch") || hostname.endsWith("player.rsi.ch") || hostname.endsWith("player.rtr.ch") || hostname.endsWith("player.swissinfo.ch") || hostname.endsWith("player.srf.ch") || (hostname.includes("srgssr") && pathname.startsWith("/srgletterbox-web")):
+			return "lb";
+		case (hostname.includes("rts.ch") && !hostname.includes("play-staging")) || hostname.includes("srgplayer-rts") || (hostname.includes("play-mmf") && pathname.startsWith("/rts/")) || ((hostname.includes("play-web") || hostname.includes("play-staging")) && pathname.startsWith("/rts/")):
+			return "rts";
+		case hostname.includes("rsi.ch") || hostname.includes("srgplayer-rsi") || (hostname.includes("play-mmf") && pathname.startsWith("/rsi/")) || ((hostname.includes("play-web") || hostname.includes("play-staging")) && pathname.startsWith("/rsi/")):
+			return "rsi";
+		case hostname.includes("rtr.ch") || hostname.includes("srgplayer-rtr") || (hostname.includes("play-mmf") && pathname.startsWith("/rtr/")) || ((hostname.includes("play-web") || hostname.includes("play-staging")) && pathname.startsWith("/rtr/")):
+			return "rtr";
+		case hostname.includes("swissinfo.ch") || hostname.includes("srgplayer-swi") || (hostname.includes("play-mmf") && pathname.startsWith("/swi/")) || ((hostname.includes("play-web") || hostname.includes("play-staging")) && pathname.startsWith("/swi/")):
+			return "swi";
+		case hostname.includes("srf.ch") || hostname.includes("srgplayer-srf") || (hostname.includes("play-mmf") && pathname.startsWith("/srf/")) || ((hostname.includes("play-web") || hostname.includes("play-staging")) && pathname.startsWith("/srf/")):
+			return "srf";
+		case hostname.includes("play-mmf") && pathname.startsWith("/mmf/"):
+			return "mmf";
+		case hostname.includes("radioswisspop.ch") || hostname.includes("radioswissclassic.ch") || hostname.includes("radioswissjazz.ch"):
+			return "radioswiss";
+	}
+	return null;
+}
 
- function getBuFromPathname(pathname) {
-    switch (true) {
-    	case pathname.endsWith("rsi"):
+function getBuFromPathname(pathname) {
+	switch (true) {
+		case pathname.endsWith("rsi"):
 			return "rsi";
 		case pathname.endsWith("rtr"):
 			return "rtr";
@@ -1035,7 +1035,7 @@ function getBuFromHostname(hostname, pathname) {
 			return "swi";
 	}
 	return null;
- }
+}
 
 /**
 * Build scheme://host[/path][?queryParams[0]&...&queryParams[n-1]]
@@ -1043,26 +1043,26 @@ function getBuFromHostname(hostname, pathname) {
 *   playrts://media/urn:xxx?position=0&server=mmf
 */
 function buildUri(scheme, host, path, queryParams) {
-    var uri = scheme + "://" + host;
-    if (path) {
-        uri = uri + "/" + path;
-    }
-    if (queryParams && queryParams !== {}) {
-        uri = uri + "?";
-        var optionIndex = 0;
-        for (var option in queryParams) {
-            if (queryParams[option]) {
-               if (optionIndex > 0) {
-                    uri = uri + "&";
-               }
-               uri = uri + option + "=" + encodeURIComponent(queryParams[option]);
-               optionIndex++;
-            }
-        }
-    }
-    return uri;
+	var uri = scheme + "://" + host;
+	if (path) {
+		uri = uri + "/" + path;
+	}
+	if (queryParams && queryParams !== {}) {
+		uri = uri + "?";
+		var optionIndex = 0;
+		for (var option in queryParams) {
+			if (queryParams[option]) {
+				if (optionIndex > 0) {
+					uri = uri + "&";
+				}
+				uri = uri + option + "=" + encodeURIComponent(queryParams[option]);
+				optionIndex++;
+			}
+		}
+	}
+	return uri;
 }
 
 function buildBuUri(bu, host, path, queryParams) {
-    return buildUri(schemeForBu(bu), host, path, queryParams);
+	return buildUri(schemeForBu(bu), host, path, queryParams);
 }


### PR DESCRIPTION
### Motivation and Context

**As** a user or an integrator
**I want to** link new new BU-livetreams urls to the "livestreams" tab on mobile apps
**so that** I can find "web only" livestreams (sports, sign languages, etc).

### Description

Update `parsePlayUrl.js` files.

UTs are on Play MMF:
https://play-mmf.herokuapp.com/deeplink/tests/index.html

### Checklist

- [x] The branch has been rebased onto the `main` branch.
- [x] The green check mark "All checks have passed" is displayed on the PR.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
