### PR TITLE
Reduce recommendation id unicity to show urn only

### DIFF
--- a/src/main/java/ch/srgssr/playfff/service/RecommendationService.java
+++ b/src/main/java/ch/srgssr/playfff/service/RecommendationService.java
@@ -106,7 +106,6 @@ public class RecommendationService {
         }
 
         String showURN = media.getShow().getUrn();
-        long timestamp = System.currentTimeMillis();
         EpisodeComposition episodeComposition = integrationLayerRequest.getEpisodeCompositionLatestByShow(showURN, null, 100, Environment.PROD);
         if (episodeComposition == null) {
             return new RecommendedList();
@@ -209,7 +208,7 @@ public class RecommendationService {
         }
 
         String host = "playfff.srgssr.ch";
-        String recommendationId = "EpisodeComposition/LatestByShow/" + showURN + "/" + ((isFullLengthUrns) ? "FullLength/" : "Clip/") + urn + "/" + timestamp;
+        String recommendationId = "EpisodeComposition/LatestByShow/" + showURN;
 
         if (recommendationResult.size() > 49) {
             recommendationResult = recommendationResult.subList(0, 49);

--- a/src/test/java/ch/srgssr/playfff/controller/RecommendationServiceAudioResultTests.java
+++ b/src/test/java/ch/srgssr/playfff/controller/RecommendationServiceAudioResultTests.java
@@ -66,7 +66,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:1";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:2", "urn:rts:audio:3");
 
-        testAudioRecommendation(urn, true,true, expectedUrns);
+        testAudioRecommendation(urn,true, expectedUrns);
     }
 
     @Test
@@ -74,7 +74,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:1";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:2", "urn:rts:audio:3", "urn:rts:audio:4");
 
-        testAudioRecommendation(urn, true,false, expectedUrns);
+        testAudioRecommendation(urn,false, expectedUrns);
     }
 
     @Test
@@ -82,7 +82,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:2";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:3", "urn:rts:audio:1");
 
-        testAudioRecommendation(urn, true,true, expectedUrns);
+        testAudioRecommendation(urn,true, expectedUrns);
     }
 
     @Test
@@ -90,7 +90,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:2";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:3", "urn:rts:audio:4", "urn:rts:audio:1");
 
-        testAudioRecommendation(urn, true,false, expectedUrns);
+        testAudioRecommendation(urn,false, expectedUrns);
     }
 
     @Test
@@ -98,7 +98,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:3";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:4", "urn:rts:audio:2", "urn:rts:audio:1");
 
-        testAudioRecommendation(urn, true,false, expectedUrns);
+        testAudioRecommendation(urn,false, expectedUrns);
     }
 
     @Test
@@ -106,7 +106,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:3";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:1", "urn:rts:audio:2");
 
-        testAudioRecommendation(urn, true,true, expectedUrns);
+        testAudioRecommendation(urn,true, expectedUrns);
     }
 
     @Test
@@ -114,7 +114,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:4";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:3", "urn:rts:audio:2", "urn:rts:audio:1");
 
-        testAudioRecommendation(urn, true,false, expectedUrns);
+        testAudioRecommendation(urn,false, expectedUrns);
     }
 
     @Test
@@ -122,7 +122,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:0";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:1", "urn:rts:audio:2", "urn:rts:audio:3");
 
-        testAudioRecommendation(urn, true,true, expectedUrns);
+        testAudioRecommendation(urn,true, expectedUrns);
     }
 
     @Test
@@ -130,7 +130,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:0";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:4", "urn:rts:audio:3", "urn:rts:audio:2", "urn:rts:audio:1");
 
-        testAudioRecommendation(urn, true,false, expectedUrns);
+        testAudioRecommendation(urn,false, expectedUrns);
     }
 
     @Test
@@ -138,7 +138,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:11";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:12", "urn:rts:audio:21", "urn:rts:audio:22", "urn:rts:audio:31", "urn:rts:audio:32");
 
-        testAudioRecommendation(urn, false,true, expectedUrns);
+        testAudioRecommendation(urn,true, expectedUrns);
     }
 
     @Test
@@ -146,7 +146,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:11";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:12", "urn:rts:audio:21", "urn:rts:audio:22", "urn:rts:audio:31", "urn:rts:audio:32", "urn:rts:audio:41", "urn:rts:audio:42");
 
-        testAudioRecommendation(urn, false,false, expectedUrns);
+        testAudioRecommendation(urn,false, expectedUrns);
     }
 
     @Test
@@ -154,7 +154,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:31";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:32", "urn:rts:audio:11", "urn:rts:audio:12", "urn:rts:audio:21", "urn:rts:audio:22");
 
-        testAudioRecommendation(urn, false,true, expectedUrns);
+        testAudioRecommendation(urn,true, expectedUrns);
     }
 
     @Test
@@ -162,7 +162,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:31";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:32", "urn:rts:audio:41", "urn:rts:audio:42", "urn:rts:audio:22", "urn:rts:audio:21", "urn:rts:audio:12", "urn:rts:audio:11");
 
-        testAudioRecommendation(urn, false,false, expectedUrns);
+        testAudioRecommendation(urn,false, expectedUrns);
     }
 
     @Test
@@ -170,7 +170,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:32";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:11", "urn:rts:audio:12", "urn:rts:audio:21", "urn:rts:audio:22", "urn:rts:audio:31");
 
-        testAudioRecommendation(urn, false,true, expectedUrns);
+        testAudioRecommendation(urn,true, expectedUrns);
     }
 
     @Test
@@ -178,7 +178,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:42";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:41", "urn:rts:audio:32", "urn:rts:audio:31", "urn:rts:audio:22", "urn:rts:audio:21", "urn:rts:audio:12", "urn:rts:audio:11");
 
-        testAudioRecommendation(urn, false,false, expectedUrns);
+        testAudioRecommendation(urn,false, expectedUrns);
     }
 
     @Test
@@ -186,7 +186,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:01";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:11", "urn:rts:audio:12", "urn:rts:audio:21", "urn:rts:audio:22", "urn:rts:audio:31", "urn:rts:audio:32");
 
-        testAudioRecommendation(urn, false,true, expectedUrns);
+        testAudioRecommendation(urn,true, expectedUrns);
     }
 
     @Test
@@ -194,10 +194,10 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:01";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:42", "urn:rts:audio:41", "urn:rts:audio:32", "urn:rts:audio:31", "urn:rts:audio:22", "urn:rts:audio:21", "urn:rts:audio:12", "urn:rts:audio:11");
 
-        testAudioRecommendation(urn, false,false, expectedUrns);
+        testAudioRecommendation(urn,false, expectedUrns);
     }
 
-    private void testAudioRecommendation(String urn, boolean isFullLength, boolean isShortPodcast, List<String> expectedUrns) throws URISyntaxException {
+    private void testAudioRecommendation(String urn, boolean isShortPodcast, List<String> expectedUrns) throws URISyntaxException {
         String mediaFileName = urn.replace(":", "-") + ".json";
         String mediaJson = BaseResourceString.getString(applicationContext, mediaFileName);
         mockServer.expect(ExpectedCount.times(2),
@@ -230,22 +230,16 @@ public class RecommendationServiceAudioResultTests {
                     );
         } catch (Exception e) {}
 
-        String expectedRecommendationId = isFullLength ? "ch.srgssr.playfff:EpisodeComposition/LatestByShow/urn:rts:show:radio:1234/FullLength/" + urn : "ch.srgssr.playfff:EpisodeComposition/LatestByShow/urn:rts:show:radio:1234/Clip/" + urn;
+        String expectedRecommendationId = "ch.srgssr.playfff:EpisodeComposition/LatestByShow/urn:rts:show:radio:1234";
 
         RecommendedList recommendedList1 = recommendationService.getRecommendedUrns("continuousplayback", urn, false);
         Assert.assertNotNull(recommendedList1);
-        String recommendationId1 = recommendedList1.getRecommendationId();
-        // Remove timestamp part
-        recommendationId1 = recommendationId1.substring(0, recommendationId1.lastIndexOf("/"));
-        Assert.assertEquals(expectedRecommendationId, recommendationId1);
+        Assert.assertEquals(expectedRecommendationId, recommendedList1.getRecommendationId());
         Assert.assertEquals(expectedUrns, recommendedList1.getUrns());
 
         RecommendedList recommendedList2 = recommendationService.getRecommendedUrns("continuousplayback", urn, true);
         Assert.assertNotNull(recommendedList2);
-        String recommendationId2 = recommendedList2.getRecommendationId();
-        // Remove timestamp part
-        recommendationId2 = recommendationId2.substring(0, recommendationId2.lastIndexOf("/"));
-        Assert.assertEquals(expectedRecommendationId, recommendationId2);
+        Assert.assertEquals(expectedRecommendationId, recommendedList2.getRecommendationId());
         Assert.assertEquals(expectedUrns, recommendedList2.getUrns());
 
         mockServer.verify();

--- a/src/test/java/ch/srgssr/playfff/controller/RecommendationServiceRSIOneFullLengthVideoResultTests.java
+++ b/src/test/java/ch/srgssr/playfff/controller/RecommendationServiceRSIOneFullLengthVideoResultTests.java
@@ -70,7 +70,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:2", "urn:rsi:video:3");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:2", "urn:rsi:video:3");
 
-        testVideoRecommendation(urn, true,true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -79,7 +79,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:2", "urn:rsi:video:3", "urn:rsi:video:4");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:2", "urn:rsi:video:3", "urn:rsi:video:4");
 
-        testVideoRecommendation(urn, true,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -88,7 +88,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:3", "urn:rsi:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:3", "urn:rsi:video:1");
 
-        testVideoRecommendation(urn, true,true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -97,7 +97,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:3", "urn:rsi:video:4", "urn:rsi:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:3", "urn:rsi:video:4", "urn:rsi:video:1");
 
-        testVideoRecommendation(urn, true,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -106,7 +106,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:4", "urn:rsi:video:2", "urn:rsi:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:4", "urn:rsi:video:2", "urn:rsi:video:1");
 
-        testVideoRecommendation(urn, true,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -115,7 +115,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:1", "urn:rsi:video:2");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:1", "urn:rsi:video:2");
 
-        testVideoRecommendation(urn, true,true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -124,7 +124,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:3", "urn:rsi:video:2", "urn:rsi:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:3", "urn:rsi:video:2", "urn:rsi:video:1");
 
-        testVideoRecommendation(urn, true,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -133,7 +133,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:1", "urn:rsi:video:2", "urn:rsi:video:3");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:1", "urn:rsi:video:2", "urn:rsi:video:3");
 
-        testVideoRecommendation(urn, true,true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -142,7 +142,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:4", "urn:rsi:video:3", "urn:rsi:video:2", "urn:rsi:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:4", "urn:rsi:video:3", "urn:rsi:video:2", "urn:rsi:video:1");
 
-        testVideoRecommendation(urn, true,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
 
@@ -152,7 +152,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:2", "urn:rsi:video:3");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:2", "urn:rsi:video:3");
 
-        testVideoRecommendation(urn, false,true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -161,7 +161,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:2", "urn:rsi:video:3", "urn:rsi:video:4");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:2", "urn:rsi:video:3", "urn:rsi:video:4");
 
-        testVideoRecommendation(urn, false,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -170,7 +170,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:4", "urn:rsi:video:2", "urn:rsi:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:4", "urn:rsi:video:2", "urn:rsi:video:1");
 
-        testVideoRecommendation(urn, false,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -179,7 +179,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:1", "urn:rsi:video:2");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:1", "urn:rsi:video:2");
 
-        testVideoRecommendation(urn, false,true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -188,7 +188,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:3", "urn:rsi:video:2", "urn:rsi:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:3", "urn:rsi:video:2", "urn:rsi:video:1");
 
-        testVideoRecommendation(urn, false,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -197,7 +197,7 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:1", "urn:rsi:video:2", "urn:rsi:video:3");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:1", "urn:rsi:video:2", "urn:rsi:video:3");
 
-        testVideoRecommendation(urn, false,true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -206,10 +206,10 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:4", "urn:rsi:video:3", "urn:rsi:video:2", "urn:rsi:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:4", "urn:rsi:video:3", "urn:rsi:video:2", "urn:rsi:video:1");
 
-        testVideoRecommendation(urn, false,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
-    private void testVideoRecommendation(String urn, boolean isFullLength, boolean isShortPodcast, List<String> expectedUrns, List<String> expectedStandaloneUrns) throws URISyntaxException {
+    private void testVideoRecommendation(String urn, boolean isShortPodcast, List<String> expectedUrns, List<String> expectedStandaloneUrns) throws URISyntaxException {
         String mediaFileName = urn.replace(":", "-") + ".json";
         String mediaJson = BaseResourceString.getString(applicationContext, mediaFileName);
         mockServer.expect(ExpectedCount.times(2),
@@ -242,22 +242,16 @@ public class RecommendationServiceRSIOneFullLengthVideoResultTests {
                     );
         } catch (Exception e) {}
 
-        String expectedRecommendationId = isFullLength ? "ch.srgssr.playfff:EpisodeComposition/LatestByShow/urn:rsi:show:tv:1234/FullLength/" + urn : "ch.srgssr.playfff:EpisodeComposition/LatestByShow/urn:rsi:show:tv:1234/Clip/" + urn;
+        String expectedRecommendationId = "ch.srgssr.playfff:EpisodeComposition/LatestByShow/urn:rsi:show:tv:1234";
 
         RecommendedList recommendedList1 = recommendationService.getRecommendedUrns("continuousplayback", urn, false);
         Assert.assertNotNull(recommendedList1);
-        String recommendationId1 = recommendedList1.getRecommendationId();
-        // Remove timestamp part
-        recommendationId1 = recommendationId1.substring(0, recommendationId1.lastIndexOf("/"));
-        Assert.assertEquals(expectedRecommendationId, recommendationId1);
+        Assert.assertEquals(expectedRecommendationId, recommendedList1.getRecommendationId());
         Assert.assertEquals(expectedUrns, recommendedList1.getUrns());
 
         RecommendedList recommendedList2 = recommendationService.getRecommendedUrns("continuousplayback", urn, true);
         Assert.assertNotNull(recommendedList2);
-        String recommendationId2 = recommendedList2.getRecommendationId();
-        // Remove timestamp part
-        recommendationId2 = recommendationId2.substring(0, recommendationId2.lastIndexOf("/"));
-        Assert.assertEquals(expectedRecommendationId, recommendationId2);
+        Assert.assertEquals(expectedRecommendationId, recommendedList2.getRecommendationId());
         Assert.assertEquals(expectedStandaloneUrns, recommendedList2.getUrns());
 
         mockServer.verify();

--- a/src/test/java/ch/srgssr/playfff/controller/RecommendationServiceRSIVideoResultTests.java
+++ b/src/test/java/ch/srgssr/playfff/controller/RecommendationServiceRSIVideoResultTests.java
@@ -70,7 +70,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:2b", "urn:rsi:video:3b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:2b", "urn:rsi:video:3b");
 
-        testVideoRecommendation(urn, true,true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -79,7 +79,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:2b", "urn:rsi:video:3b", "urn:rsi:video:4b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:2b", "urn:rsi:video:3b", "urn:rsi:video:4b");
 
-        testVideoRecommendation(urn, true,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -88,7 +88,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:3b", "urn:rsi:video:1b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:3b", "urn:rsi:video:1b");
 
-        testVideoRecommendation(urn, true,true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -97,7 +97,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:3b", "urn:rsi:video:4b", "urn:rsi:video:1b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:3b", "urn:rsi:video:4b", "urn:rsi:video:1b");
 
-        testVideoRecommendation(urn, true,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -106,7 +106,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:4b", "urn:rsi:video:2b", "urn:rsi:video:1b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:4b", "urn:rsi:video:2b", "urn:rsi:video:1b");
 
-        testVideoRecommendation(urn, true,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -115,7 +115,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:1b", "urn:rsi:video:2b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:1b", "urn:rsi:video:2b");
 
-        testVideoRecommendation(urn, true,true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -124,7 +124,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:3b", "urn:rsi:video:2b", "urn:rsi:video:1b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:3b", "urn:rsi:video:2b", "urn:rsi:video:1b");
 
-        testVideoRecommendation(urn, true,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -133,7 +133,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:1b", "urn:rsi:video:2b", "urn:rsi:video:3b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:1b", "urn:rsi:video:2b", "urn:rsi:video:3b");
 
-        testVideoRecommendation(urn, true,true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -142,7 +142,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:4b", "urn:rsi:video:3b", "urn:rsi:video:2b", "urn:rsi:video:1b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:4b", "urn:rsi:video:3b", "urn:rsi:video:2b", "urn:rsi:video:1b");
 
-        testVideoRecommendation(urn, true,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
 
@@ -152,7 +152,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:2b", "urn:rsi:video:3b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:2b", "urn:rsi:video:3b");
 
-        testVideoRecommendation(urn, false,true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -161,7 +161,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:2b", "urn:rsi:video:3b", "urn:rsi:video:4b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:2b", "urn:rsi:video:3b", "urn:rsi:video:4b");
 
-        testVideoRecommendation(urn, false,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -170,7 +170,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:4b", "urn:rsi:video:2b", "urn:rsi:video:1b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:4b", "urn:rsi:video:2b", "urn:rsi:video:1b");
 
-        testVideoRecommendation(urn, false,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -179,7 +179,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:1b", "urn:rsi:video:2b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:1b", "urn:rsi:video:2b");
 
-        testVideoRecommendation(urn, false,true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -188,7 +188,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:3b", "urn:rsi:video:2b", "urn:rsi:video:1b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:3b", "urn:rsi:video:2b", "urn:rsi:video:1b");
 
-        testVideoRecommendation(urn, false,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -197,7 +197,7 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:1b", "urn:rsi:video:2b", "urn:rsi:video:3b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:1b", "urn:rsi:video:2b", "urn:rsi:video:3b");
 
-        testVideoRecommendation(urn, false,true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -206,10 +206,10 @@ public class RecommendationServiceRSIVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rsi:video:4b", "urn:rsi:video:3b", "urn:rsi:video:2b", "urn:rsi:video:1b");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rsi:video:4b", "urn:rsi:video:3b", "urn:rsi:video:2b", "urn:rsi:video:1b");
 
-        testVideoRecommendation(urn, false,false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, expectedUrns, expectedStandaloneUrns);
     }
 
-    private void testVideoRecommendation(String urn, boolean isFullLength, boolean isShortPodcast, List<String> expectedUrns, List<String> expectedStandaloneUrns) throws URISyntaxException {
+    private void testVideoRecommendation(String urn, boolean isShortPodcast, List<String> expectedUrns, List<String> expectedStandaloneUrns) throws URISyntaxException {
         String mediaFileName = urn.replace(":", "-") + ".json";
         String mediaJson = BaseResourceString.getString(applicationContext, mediaFileName);
         mockServer.expect(ExpectedCount.times(2),
@@ -242,22 +242,16 @@ public class RecommendationServiceRSIVideoResultTests {
                     );
         } catch (Exception e) {}
 
-        String expectedRecommendationId = isFullLength ? "ch.srgssr.playfff:EpisodeComposition/LatestByShow/urn:rsi:show:tv:1234/FullLength/" + urn : "ch.srgssr.playfff:EpisodeComposition/LatestByShow/urn:rsi:show:tv:1234/Clip/" + urn;
+        String expectedRecommendationId = "ch.srgssr.playfff:EpisodeComposition/LatestByShow/urn:rsi:show:tv:1234";
 
         RecommendedList recommendedList1 = recommendationService.getRecommendedUrns("continuousplayback", urn, false);
         Assert.assertNotNull(recommendedList1);
-        String recommendationId1 = recommendedList1.getRecommendationId();
-        // Remove timestamp part
-        recommendationId1 = recommendationId1.substring(0, recommendationId1.lastIndexOf("/"));
-        Assert.assertEquals(expectedRecommendationId, recommendationId1);
+        Assert.assertEquals(expectedRecommendationId, recommendedList1.getRecommendationId());
         Assert.assertEquals(expectedUrns, recommendedList1.getUrns());
 
         RecommendedList recommendedList2 = recommendationService.getRecommendedUrns("continuousplayback", urn, true);
         Assert.assertNotNull(recommendedList2);
-        String recommendationId2 = recommendedList2.getRecommendationId();
-        // Remove timestamp part
-        recommendationId2 = recommendationId2.substring(0, recommendationId2.lastIndexOf("/"));
-        Assert.assertEquals(expectedRecommendationId, recommendationId2);
+        Assert.assertEquals(expectedRecommendationId, recommendedList2.getRecommendationId());
         Assert.assertEquals(expectedStandaloneUrns, recommendedList2.getUrns());
 
         mockServer.verify();

--- a/src/test/java/ch/srgssr/playfff/controller/RecommendationServiceTests.java
+++ b/src/test/java/ch/srgssr/playfff/controller/RecommendationServiceTests.java
@@ -49,8 +49,7 @@ public class RecommendationServiceTests {
         RecommendedList recommendedList = recommendationService.getRecommendedUrns(purpose, mediaURN, standalone);
 
         Assert.assertNotNull(recommendedList.getRecommendationId());
-        Assert.assertTrue(recommendedList.getRecommendationId().startsWith("ch.srgssr.playfff:EpisodeComposition/LatestByShow/" + showURN + "/FullLength/"));
-        Assert.assertTrue(recommendedList.getRecommendationId().contains(mediaURN));
+        Assert.assertEquals(recommendedList.getRecommendationId(),"ch.srgssr.playfff:EpisodeComposition/LatestByShow/" + showURN);
         assertValidList(recommendedList);
     }
 
@@ -63,8 +62,7 @@ public class RecommendationServiceTests {
         RecommendedList recommendedList = recommendationService.getRecommendedUrns(purpose, mediaURN, standalone);
 
         Assert.assertNotNull(recommendedList.getRecommendationId());
-        Assert.assertTrue(recommendedList.getRecommendationId().startsWith("ch.srgssr.playfff:EpisodeComposition/LatestByShow/" + showURN + "/FullLength/"));
-        Assert.assertTrue(recommendedList.getRecommendationId().contains(mediaURN));
+        Assert.assertEquals(recommendedList.getRecommendationId(), "ch.srgssr.playfff:EpisodeComposition/LatestByShow/" + showURN);
         assertValidList(recommendedList);
     }
 
@@ -77,8 +75,7 @@ public class RecommendationServiceTests {
         RecommendedList recommendedList = recommendationService.getRecommendedUrns(purpose, mediaURN, standalone);
 
         Assert.assertNotNull(recommendedList.getRecommendationId());
-        Assert.assertTrue(recommendedList.getRecommendationId().startsWith("ch.srgssr.playfff:EpisodeComposition/LatestByShow/" + showURN + "/Clip/"));
-        Assert.assertTrue(recommendedList.getRecommendationId().contains(mediaURN));
+        Assert.assertEquals(recommendedList.getRecommendationId(), "ch.srgssr.playfff:EpisodeComposition/LatestByShow/" + showURN);
         assertValidList(recommendedList);
     }
 
@@ -91,8 +88,7 @@ public class RecommendationServiceTests {
         RecommendedList recommendedList = recommendationService.getRecommendedUrns(purpose, mediaURN, standalone);
 
         Assert.assertNotNull(recommendedList.getRecommendationId());
-        Assert.assertTrue(recommendedList.getRecommendationId().startsWith("ch.srgssr.playfff:EpisodeComposition/LatestByShow/" + showURN + "/Clip/"));
-        Assert.assertTrue(recommendedList.getRecommendationId().contains(mediaURN));
+        Assert.assertEquals(recommendedList.getRecommendationId(), "ch.srgssr.playfff:EpisodeComposition/LatestByShow/" + showURN);
         assertValidList(recommendedList);
     }
 

--- a/src/test/java/ch/srgssr/playfff/controller/RecommendationServiceVideoResultTests.java
+++ b/src/test/java/ch/srgssr/playfff/controller/RecommendationServiceVideoResultTests.java
@@ -67,7 +67,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:2", "urn:rtr:video:3");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:2", "urn:rtr:video:3");
 
-        testVideoRecommendation(urn, true,true, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -76,7 +76,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:2", "urn:rtr:video:3", "urn:rtr:video:4");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:2", "urn:rtr:video:3", "urn:rtr:video:4");
 
-        testVideoRecommendation(urn, true,false, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -85,7 +85,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:3", "urn:rtr:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:3", "urn:rtr:video:1");
 
-        testVideoRecommendation(urn, true,true, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -94,7 +94,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:3", "urn:rtr:video:4", "urn:rtr:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:3", "urn:rtr:video:4", "urn:rtr:video:1");
 
-        testVideoRecommendation(urn, true,false, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -103,7 +103,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:4", "urn:rtr:video:2", "urn:rtr:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:4", "urn:rtr:video:2", "urn:rtr:video:1");
 
-        testVideoRecommendation(urn, true,false, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -112,7 +112,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:1", "urn:rtr:video:2");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:1", "urn:rtr:video:2");
 
-        testVideoRecommendation(urn, true,true, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -121,7 +121,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:3", "urn:rtr:video:2", "urn:rtr:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:3", "urn:rtr:video:2", "urn:rtr:video:1");
 
-        testVideoRecommendation(urn, true,false, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -130,7 +130,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:1", "urn:rtr:video:2", "urn:rtr:video:3");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:1", "urn:rtr:video:2", "urn:rtr:video:3");
 
-        testVideoRecommendation(urn, true,true, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -139,7 +139,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:4", "urn:rtr:video:3", "urn:rtr:video:2", "urn:rtr:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:4", "urn:rtr:video:3", "urn:rtr:video:2", "urn:rtr:video:1");
 
-        testVideoRecommendation(urn, true,false, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, false, expectedUrns, expectedStandaloneUrns);
     }
 
 
@@ -149,7 +149,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:2", "urn:rtr:video:3");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:12", "urn:rtr:video:13", "urn:rtr:video:21", "urn:rtr:video:22", "urn:rtr:video:23", "urn:rtr:video:31", "urn:rtr:video:32", "urn:rtr:video:33");
 
-        testVideoRecommendation(urn, false,true, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -158,7 +158,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:2", "urn:rtr:video:3", "urn:rtr:video:4");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:12", "urn:rtr:video:13", "urn:rtr:video:21", "urn:rtr:video:22", "urn:rtr:video:23", "urn:rtr:video:31", "urn:rtr:video:32", "urn:rtr:video:33", "urn:rtr:video:41", "urn:rtr:video:42", "urn:rtr:video:43");
 
-        testVideoRecommendation(urn, false,false, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -167,7 +167,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:4", "urn:rtr:video:2", "urn:rtr:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:32", "urn:rtr:video:33", "urn:rtr:video:41", "urn:rtr:video:42", "urn:rtr:video:43", "urn:rtr:video:23", "urn:rtr:video:22", "urn:rtr:video:21", "urn:rtr:video:13", "urn:rtr:video:12", "urn:rtr:video:11");
 
-        testVideoRecommendation(urn, false,false, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -176,7 +176,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:1", "urn:rtr:video:2");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:11", "urn:rtr:video:12", "urn:rtr:video:13", "urn:rtr:video:21", "urn:rtr:video:22", "urn:rtr:video:23", "urn:rtr:video:31", "urn:rtr:video:32");
 
-        testVideoRecommendation(urn, false,true, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -185,7 +185,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:3", "urn:rtr:video:2", "urn:rtr:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:42", "urn:rtr:video:41", "urn:rtr:video:33", "urn:rtr:video:32", "urn:rtr:video:31", "urn:rtr:video:23", "urn:rtr:video:22", "urn:rtr:video:21", "urn:rtr:video:13", "urn:rtr:video:12", "urn:rtr:video:11");
 
-        testVideoRecommendation(urn, false,false, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -194,7 +194,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:1", "urn:rtr:video:2", "urn:rtr:video:3");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:11", "urn:rtr:video:12", "urn:rtr:video:13", "urn:rtr:video:21", "urn:rtr:video:22", "urn:rtr:video:23", "urn:rtr:video:31", "urn:rtr:video:32", "urn:rtr:video:33");
 
-        testVideoRecommendation(urn, false,true, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -203,7 +203,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:4", "urn:rtr:video:3", "urn:rtr:video:2", "urn:rtr:video:1");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:43", "urn:rtr:video:42", "urn:rtr:video:41", "urn:rtr:video:33", "urn:rtr:video:32", "urn:rtr:video:31", "urn:rtr:video:23", "urn:rtr:video:22", "urn:rtr:video:21", "urn:rtr:video:13", "urn:rtr:video:12", "urn:rtr:video:11");
 
-        testVideoRecommendation(urn, false,false, false, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, false, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -213,7 +213,7 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:2", "urn:rtr:video:3");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:2", "urn:rtr:video:3");
 
-        testVideoRecommendation(urn, true,true, true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,true, true, expectedUrns, expectedStandaloneUrns);
     }
 
     @Test
@@ -223,10 +223,10 @@ public class RecommendationServiceVideoResultTests {
         List<String> expectedUrns = Arrays.asList("urn:rtr:video:2", "urn:rtr:video:3", "urn:rtr:video:4");
         List<String> expectedStandaloneUrns = Arrays.asList("urn:rtr:video:2", "urn:rtr:video:3", "urn:rtr:video:4");
 
-        testVideoRecommendation(urn, true,false, true, expectedUrns, expectedStandaloneUrns);
+        testVideoRecommendation(urn,false, true, expectedUrns, expectedStandaloneUrns);
     }
 
-    private void testVideoRecommendation(String urn, boolean isFullLength, boolean isShortPodcast, boolean isBingeWatching, List<String> expectedUrns, List<String> expectedStandaloneUrns) throws URISyntaxException {
+    private void testVideoRecommendation(String urn, boolean isShortPodcast, boolean isBingeWatching, List<String> expectedUrns, List<String> expectedStandaloneUrns) throws URISyntaxException {
         String mediaFileName = urn.replace(":", "-") + ".json";
         String mediaJson = BaseResourceString.getString(applicationContext, mediaFileName);
         mockServer.expect(ExpectedCount.times(2),
@@ -260,22 +260,16 @@ public class RecommendationServiceVideoResultTests {
                     );
         } catch (Exception e) {}
 
-        String expectedRecommendationId = isFullLength ? "ch.srgssr.playfff:EpisodeComposition/LatestByShow/urn:rtr:show:tv:1234/FullLength/" + urn : "ch.srgssr.playfff:EpisodeComposition/LatestByShow/urn:rtr:show:tv:1234/Clip/" + urn;
+        String expectedRecommendationId = "ch.srgssr.playfff:EpisodeComposition/LatestByShow/urn:rtr:show:tv:1234";
 
         RecommendedList recommendedList1 = recommendationService.getRecommendedUrns("continuousplayback", urn, false);
         Assert.assertNotNull(recommendedList1);
-        String recommendationId1 = recommendedList1.getRecommendationId();
-        // Remove timestamp part
-        recommendationId1 = recommendationId1.substring(0, recommendationId1.lastIndexOf("/"));
-        Assert.assertEquals(expectedRecommendationId, recommendationId1);
+        Assert.assertEquals(expectedRecommendationId, recommendedList1.getRecommendationId());
         Assert.assertEquals(expectedUrns, recommendedList1.getUrns());
 
         RecommendedList recommendedList2 = recommendationService.getRecommendedUrns("continuousplayback", urn, true);
         Assert.assertNotNull(recommendedList2);
-        String recommendationId2 = recommendedList2.getRecommendationId();
-        // Remove timestamp part
-        recommendationId2 = recommendationId2.substring(0, recommendationId2.lastIndexOf("/"));
-        Assert.assertEquals(expectedRecommendationId, recommendationId2);
+        Assert.assertEquals(expectedRecommendationId, recommendedList2.getRecommendationId());
         Assert.assertEquals(expectedStandaloneUrns, recommendedList2.getUrns());
 
         mockServer.verify();


### PR DESCRIPTION
### Motivation and Context

SRGSSR would like to reduce unique values for hidden event `value1` property.
Play SRG mobile applications use the recommendation id. It's will be removed in future update.
But in the meantime, the Playfff recommendation service can reduce unique values.  

### Description

- Reduce `Playfff` recommendation id with only the show urn. No more timestamp and full length information.
- Update unit tests. 

### Checklist

- [x] The branch has been rebased onto the `main` branch.
- [x] The green check mark "All checks have passed" is displayed on the PR.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
