### PR TITLE
Deeplink: fix play path component check

### DIFF
--- a/src/main/resources/deeplink/v1/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v1/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 35;
+var parsePlayUrlVersion = 36;
 var parsePlayUrlBuild = "mmf";
 
 if (!console) {
@@ -200,8 +200,8 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 		}
 	}
 
-	if (!pathname.startsWith("/play")) {
-		console.log("No /play path in url.");
+	if (!(pathname == "/play" || pathname.startsWith("/play/"))) {
+		console.log("No /play path component in url.");
 		return null;
 	}
 

--- a/src/main/resources/deeplink/v2/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v2/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 35;
+var parsePlayUrlVersion = 36;
 var parsePlayUrlBuild = "mmf";
 
 if (!console) {
@@ -173,8 +173,8 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 		}
 	}
 
-	if (!pathname.startsWith("/play")) {
-		console.log("No /play path in url.");
+	if (!(pathname == "/play" || pathname.startsWith("/play/"))) {
+		console.log("No /play path component in url.");
 		return null;
 	}
 


### PR DESCRIPTION
### Motivation and Context

In the admin deeplink report, new entries with path like `/playfestas/#swimlane1`, from Android applications.

### Description

- Fix to set as it's not a Play url.

### Checklist

- [x] The branch has been rebased onto the `main` branch.
- [x] The green check mark "All checks have passed" is displayed on the PR.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
