### PR TITLE
Add Package name in admin deeplink UI

### DIFF
--- a/portal-app/src/app/deeplink/deeplink.component.css
+++ b/portal-app/src/app/deeplink/deeplink.component.css
@@ -1,0 +1,6 @@
+.min-client-id-width {
+  min-width: 160px;
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/portal-app/src/app/deeplink/deeplink.component.html
+++ b/portal-app/src/app/deeplink/deeplink.component.html
@@ -15,10 +15,13 @@
     <tbody>
     <tr *ngFor="let deeplinkReport of deeplinkReports">
       <td *ngFor="let column of columns; let idx=index">
+        <span *ngIf="idx == 1" class="min-client-id-width">
+          <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="top" title="Package name: {{deeplinkReport[column]}}">{{packageNameFromId(deeplinkReport[column])}}</button>
+        </span>
         <span *ngIf="idx == 5">
           <a href="{{deeplinkReport[column]}}" target="_blank">{{deeplinkReport[column]}}</a>
         </span>
-        <span *ngIf="idx != 5">
+        <span *ngIf="idx != 1 && idx != 5 ">
           {{deeplinkReport[column]}}
         </span>
       </td>

--- a/portal-app/src/app/deeplink/deeplink.component.html
+++ b/portal-app/src/app/deeplink/deeplink.component.html
@@ -16,7 +16,7 @@
     <tr *ngFor="let deeplinkReport of deeplinkReports">
       <td *ngFor="let column of columns; let idx=index">
         <span *ngIf="idx == 1" class="min-client-id-width">
-          <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="top" title="Package name: {{deeplinkReport[column]}}">{{packageNameFromId(deeplinkReport[column])}}</button>
+          <button type="button" class="btn btn-secondary" title="Package name: {{deeplinkReport[column]}}">{{packageNameFromId(deeplinkReport[column])}}</button>
         </span>
         <span *ngIf="idx == 5">
           <a href="{{deeplinkReport[column]}}" target="_blank">{{deeplinkReport[column]}}</a>

--- a/portal-app/src/app/deeplink/deeplink.component.ts
+++ b/portal-app/src/app/deeplink/deeplink.component.ts
@@ -37,33 +37,31 @@ export class DeeplinkComponent implements OnInit {
       return id;
     }
 
-    if (id === "ch.rsi.player" || id.startsWith("ch.rsi.player.")) {
-      return "Play RSI Android";
-    } else if (id === "ch.rsi.rsiplayer" || id.startsWith("ch.rsi.rsiplayer.") || id.startsWith("ch.srgssr.rsiplayer.")) {
-      return "Play RSI iOS";
+    const idPrefixes: { [key: string]: string } = {
+      "ch.rsi.player": "Play RSI Android",
+      "ch.rsi.rsiplayer": "Play RSI iOS",
+      "ch.srgssr.rsiplayer": "Play RSI iOS",
+      "ch.rtr.player": "Play RTR Android",
+      "ch.rtr.rtrplayer": "Play RTR iOS",
+      "ch.srgssr.rtrplayer": "Play RTR iOS",
+      "ch.rts.player": "Play RTS Android",
+      "ch.rts.rtsplayer": "Play RTS iOS",
+      "ch.srgssr.rtsplayer": "Play RTS iOS",
+      "ch.srf.player": "Play SRF Android",
+      "ch.srf.mobile.srfplayer": "Play SRF Android",
+      "ch.srf.srfplayer": "Play SRF iOS",
+      "ch.srgssr.srfplayer": "Play SRF iOS",
+      "ch.swi.player": "Play SWI Android",
+      "ch.swi.swiplayer": "Play SWI iOS",
+      "ch.srgssr.swiplayer": "Play SWI iOS"
+    };
 
-    } else if (id === "ch.rtr.player" || id.startsWith("ch.rtr.player.")) {
-      return "Play RTR Android";
-    } else if (id === "ch.rtr.rtrplayer" || id.startsWith("ch.rtr.rtrplayer.") || id.startsWith("ch.srgssr.rtrplayer.")) {
-      return "Play RTR iOS";
-
-    } else if (id === "ch.rts.player" || id.startsWith("ch.rts.player.")) {
-      return "Play RTS Android";
-    } else if (id === "ch.rts.rtsplayer" || id.startsWith("ch.rts.rtsplayer.") || id.startsWith("ch.srgssr.rtsplayer.")) {
-      return "Play RTS iOS";
-
-    } else if (id === "ch.srf.player" || id.startsWith("ch.srf.player.") || id === "ch.srf.mobile.srfplayer" || id.startsWith("ch.srf.mobile.srfplayer.")) {
-      return "Play SRF Android";
-    } else if (id === "ch.srf.srfplayer" || id.startsWith("ch.srf.srfplayer.") || id.startsWith("ch.srgssr.srfplayer.")) {
-      return "Play SRF iOS";
-
-    } else if (id === "ch.swi.player" || id.startsWith("ch.swi.player.")) {
-      return "Play SWI Android";
-    } else if (id === "ch.swi.swiplayer" || id.startsWith("ch.swi.swiplayer.") || id.startsWith("ch.srgssr.swiplayer.")) {
-      return "Play SWI iOS";
-
-    } else {
-      return id;
+    for (const prefix in idPrefixes) {
+      if (id === prefix || id.startsWith(prefix + ".")) {
+        return idPrefixes[prefix];
+      }
     }
+
+    return id;
   };
 }

--- a/portal-app/src/app/deeplink/deeplink.component.ts
+++ b/portal-app/src/app/deeplink/deeplink.component.ts
@@ -31,4 +31,39 @@ export class DeeplinkComponent implements OnInit {
       })
   };
 
+
+  packageNameFromId(id: string|number): string|number {
+    if (typeof id === "number") {
+      return id;
+    }
+
+    if (id === "ch.rsi.player" || id.startsWith("ch.rsi.player.")) {
+      return "Play RSI Android";
+    } else if (id === "ch.rsi.rsiplayer" || id.startsWith("ch.rsi.rsiplayer.")) {
+      return "Play RSI iOS";
+
+    } else if (id === "ch.rtr.player" || id.startsWith("ch.rtr.player.")) {
+      return "Play RTR Android";
+    } else if (id === "ch.rtr.rtrplayer" || id.startsWith("ch.rtr.rtrplayer.")) {
+      return "Play RTR iOS";
+
+    } else if (id === "ch.rts.player" || id.startsWith("ch.rts.player.")) {
+      return "Play RTS Android";
+    } else if (id === "ch.rts.rtsplayer" || id.startsWith("ch.rts.rtsplayer.")) {
+      return "Play RTS iOS";
+
+    } else if (id === "ch.srf.player" || id.startsWith("ch.srf.player.") || id === "ch.srf.mobile.srfplayer" || id.startsWith("ch.srf.mobile.srfplayer.")) {
+      return "Play SRF Android";
+    } else if (id === "ch.srf.srfplayer" || id.startsWith("ch.srf.srfplayer.")) {
+      return "Play SRF iOS";
+
+    } else if (id === "ch.swi.player" || id.startsWith("ch.swi.player.")) {
+      return "Play SWI Android";
+    } else if (id === "ch.swi.swiplayer" || id.startsWith("ch.swi.swiplayer.")) {
+      return "Play SWI iOS";
+
+    } else {
+      return id;
+    }
+  };
 }

--- a/portal-app/src/app/deeplink/deeplink.component.ts
+++ b/portal-app/src/app/deeplink/deeplink.component.ts
@@ -39,27 +39,27 @@ export class DeeplinkComponent implements OnInit {
 
     if (id === "ch.rsi.player" || id.startsWith("ch.rsi.player.")) {
       return "Play RSI Android";
-    } else if (id === "ch.rsi.rsiplayer" || id.startsWith("ch.rsi.rsiplayer.")) {
+    } else if (id === "ch.rsi.rsiplayer" || id.startsWith("ch.rsi.rsiplayer.") || id.startsWith("ch.srgssr.rsiplayer.")) {
       return "Play RSI iOS";
 
     } else if (id === "ch.rtr.player" || id.startsWith("ch.rtr.player.")) {
       return "Play RTR Android";
-    } else if (id === "ch.rtr.rtrplayer" || id.startsWith("ch.rtr.rtrplayer.")) {
+    } else if (id === "ch.rtr.rtrplayer" || id.startsWith("ch.rtr.rtrplayer.") || id.startsWith("ch.srgssr.rtrplayer.")) {
       return "Play RTR iOS";
 
     } else if (id === "ch.rts.player" || id.startsWith("ch.rts.player.")) {
       return "Play RTS Android";
-    } else if (id === "ch.rts.rtsplayer" || id.startsWith("ch.rts.rtsplayer.")) {
+    } else if (id === "ch.rts.rtsplayer" || id.startsWith("ch.rts.rtsplayer.") || id.startsWith("ch.srgssr.rtsplayer.")) {
       return "Play RTS iOS";
 
     } else if (id === "ch.srf.player" || id.startsWith("ch.srf.player.") || id === "ch.srf.mobile.srfplayer" || id.startsWith("ch.srf.mobile.srfplayer.")) {
       return "Play SRF Android";
-    } else if (id === "ch.srf.srfplayer" || id.startsWith("ch.srf.srfplayer.")) {
+    } else if (id === "ch.srf.srfplayer" || id.startsWith("ch.srf.srfplayer.") || id.startsWith("ch.srgssr.srfplayer.")) {
       return "Play SRF iOS";
 
     } else if (id === "ch.swi.player" || id.startsWith("ch.swi.player.")) {
       return "Play SWI Android";
-    } else if (id === "ch.swi.swiplayer" || id.startsWith("ch.swi.swiplayer.")) {
+    } else if (id === "ch.swi.swiplayer" || id.startsWith("ch.swi.swiplayer.") || id.startsWith("ch.srgssr.swiplayer.")) {
       return "Play SWI iOS";
 
     } else {


### PR DESCRIPTION
### Motivation and Context

In the deeplink admin UI, the table displays the package id.
To help us, display the application name and platforms instead of the package id. Keep it as a tooltip.

### Description

- In [deeplink view](http://localhost:4200/deeplink), add a grey button with "Play [BU] [Platform]" label instead of the package id text. 

### Checklist

- [x] The branch has been rebased onto the `main` branch.
- [x] The green check mark "All checks have passed" is displayed on the PR.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
