### PR TITLE
Update ParsePlayUrl JS to version 37 with first support for micro pages

### DIFF
--- a/src/main/resources/deeplink/v1/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v1/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 36;
+var parsePlayUrlVersion = 37;
 var parsePlayUrlBuild = "mmf";
 
 if (!console) {
@@ -743,6 +743,15 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://play.swissinfo.ch/play/tv/help
 	 */
 	if (pathname.endsWith("/hilfe") || pathname.includes("/hilfe/") || pathname.endsWith("/aide") || pathname.includes("/aide/") || pathname.endsWith("/guida") || pathname.includes("/guida/") || pathname.endsWith("/agid") || pathname.includes("/agid/") || pathname.endsWith("/help") || pathname.includes("/help/")) {
+		return openURL(server, bu, scheme, hostname, pathname, queryParams, anchor);
+	}
+
+	/**
+	 * Catch play micro pages urls
+	 *
+	 * Ex: https://www.srf.ch/play/tv/micropages/test-?pageId=3c2674b9-37a7-4e76-9398-bb710bd135ee
+	 */
+	if (pathname.includes("/micropages/")) {
 		return openURL(server, bu, scheme, hostname, pathname, queryParams, anchor);
 	}
 

--- a/src/main/resources/deeplink/v2/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v2/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 36;
+var parsePlayUrlVersion = 37;
 var parsePlayUrlBuild = "mmf";
 
 if (!console) {
@@ -708,6 +708,15 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://play.swissinfo.ch/play/tv/help
 	 */
 	if (pathname.endsWith("/hilfe") || pathname.includes("/hilfe/") || pathname.endsWith("/aide") || pathname.includes("/aide/") || pathname.endsWith("/guida") || pathname.includes("/guida/") || pathname.endsWith("/agid") || pathname.includes("/agid/") || pathname.endsWith("/help") || pathname.includes("/help/")) {
+		return openURL(server, bu, scheme, hostname, pathname, queryParams, anchor);
+	}
+
+	/**
+	 * Catch play micro pages urls
+	 *
+	 * Ex: https://www.srf.ch/play/tv/micropages/test-?pageId=3c2674b9-37a7-4e76-9398-bb710bd135ee
+	 */
+	if (pathname.includes("/micropages/")) {
 		return openURL(server, bu, scheme, hostname, pathname, queryParams, anchor);
 	}
 


### PR DESCRIPTION
### Motivation and Context

Play web will introduce soon new micro pages url. Mobile application will support it natively soon.
Before the Google Play Store and AppStore release, try to redirect to Play web in web browser.


### Description

Update the ParsePlayUrl scripts.

### Checklist

- [x] The branch has been rebased onto the `main` branch.
- [x] The green check mark "All checks have passed" is displayed on the PR.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
