### PR TITLE
Deeplink: fix web url with custom app scheme transformed to link

### DIFF
--- a/src/main/resources/deeplink/v1/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v1/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 37;
+var parsePlayUrlVersion = 38;
 var parsePlayUrlBuild = "mmf";
 
 if (!console) {
@@ -741,6 +741,8 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.rtr.ch/play/tv/agid
 	 *  Ex: https://www.rtr.ch/play/tv/agid/geo-blocking
 	 *  Ex: https://play.swissinfo.ch/play/tv/help
+	 *
+	 *  Ex: playsrf://www.srf.ch/play/tv/hilfe
 	 */
 	if (pathname.endsWith("/hilfe") || pathname.includes("/hilfe/") || pathname.endsWith("/aide") || pathname.includes("/aide/") || pathname.endsWith("/guida") || pathname.includes("/guida/") || pathname.endsWith("/agid") || pathname.includes("/agid/") || pathname.endsWith("/help") || pathname.includes("/help/")) {
 		return openURL(server, bu, scheme, hostname, pathname, queryParams, anchor);
@@ -750,6 +752,8 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 * Catch play micro pages urls
 	 *
 	 * Ex: https://www.srf.ch/play/tv/micropages/test-?pageId=3c2674b9-37a7-4e76-9398-bb710bd135ee
+	 *
+	 * Ex: playsrf://www.srf.ch/play/tv/micropages/test-?pageId=3c2674b9-37a7-4e76-9398-bb710bd135ee
 	 */
 	if (pathname.includes("/micropages/")) {
 		return openURL(server, bu, scheme, hostname, pathname, queryParams, anchor);
@@ -858,6 +862,9 @@ function openURL(server, bu, scheme, hostname, pathname, queryParams, anchor) {
 	if (!scheme) {
 		scheme = "http";
 	}
+	else if (isBuScheme(scheme)) {
+		scheme = "https";
+	}
 
 	var queryParamsString = "";
 	if (queryParams) {
@@ -926,6 +933,10 @@ function schemeForBu(bu) {
 		default:
 			return null;
 	}
+}
+
+function isBuScheme(scheme) {
+	return scheme.includes("playsrf") || scheme.includes("playrts") || scheme.includes("playrsi") || scheme.includes("playrtr") || scheme.includes("playswi") || scheme.includes("letterbox");
 }
 
 function serverForUrl(hostname, pathname, queryParams) {

--- a/src/main/resources/deeplink/v2/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v2/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 37;
+var parsePlayUrlVersion = 38;
 var parsePlayUrlBuild = "mmf";
 
 if (!console) {
@@ -706,6 +706,8 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.rtr.ch/play/tv/agid
 	 *  Ex: https://www.rtr.ch/play/tv/agid/geo-blocking
 	 *  Ex: https://play.swissinfo.ch/play/tv/help
+	 *
+	 *  Ex: playsrf://www.srf.ch/play/tv/hilfe
 	 */
 	if (pathname.endsWith("/hilfe") || pathname.includes("/hilfe/") || pathname.endsWith("/aide") || pathname.includes("/aide/") || pathname.endsWith("/guida") || pathname.includes("/guida/") || pathname.endsWith("/agid") || pathname.includes("/agid/") || pathname.endsWith("/help") || pathname.includes("/help/")) {
 		return openURL(server, bu, scheme, hostname, pathname, queryParams, anchor);
@@ -715,6 +717,8 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 * Catch play micro pages urls
 	 *
 	 * Ex: https://www.srf.ch/play/tv/micropages/test-?pageId=3c2674b9-37a7-4e76-9398-bb710bd135ee
+	 *
+	 * Ex: playsrf://www.srf.ch/play/tv/micropages/test-?pageId=3c2674b9-37a7-4e76-9398-bb710bd135ee
 	 */
 	if (pathname.includes("/micropages/")) {
 		return openURL(server, bu, scheme, hostname, pathname, queryParams, anchor);
@@ -882,6 +886,9 @@ function openURL(server, bu, scheme, hostname, pathname, queryParams, anchor) {
 	if (!scheme) {
 		scheme = "http";
 	}
+	else if (isBuScheme(scheme)) {
+		scheme = "https";
+	}
 
 	var queryParamsString = "";
 	if (queryParams) {
@@ -952,6 +959,10 @@ function schemeForBu(bu) {
 		default:
 			return null;
 	}
+}
+
+function isBuScheme(scheme) {
+	return scheme.includes("playsrf") || scheme.includes("playrts") || scheme.includes("playrsi") || scheme.includes("playrtr") || scheme.includes("playswi") || scheme.includes("letterbox");
 }
 
 function serverForUrl(hostname, pathname, queryParams) {


### PR DESCRIPTION
### Motivation and Context

First try in production #85 worked from https urls shared in mails, message or whatsapp.
But it does not work on a shared url in Facebook application, which open Play web in the internal Facebook web browser.

Play web uses in html header `<meta data-react-helmet="true" property="al:ios:url"palysrf://www.srf.ch/play[…]`>.
The JS `parsePlayUrl` parses correctly the urls but as the micro page url is transformed to a `link?url=`, it keeps the app custom scheme.
It creates a loop and the application stays on the home page.

### Description

- Update JS parseUrl with a correct https link redirect even if app custom scheme url was given if the deeplink conversion is `link?url=`.
- See https://github.com/SRGSSR/playsrg-mmf/commit/860b1b2bcf9f43cd9ae4512dc53cb8ac6dfdf463 fix and tests.

### Checklist

- [x] The branch has been rebased onto the `main` branch.
- [x] The green check mark "All checks have passed" is displayed on the PR.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
