### PR TITLE
Deeplink: RSI livestream tab url in parsePlayUrl.js

### DIFF
--- a/src/main/resources/deeplink/v1/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v1/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 40;
+var parsePlayUrlVersion = 41;
 var parsePlayUrlBuild = "mmf";
 
 if (!console) {
@@ -456,8 +456,9 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.rtr.ch/play/tv/rtr-livestreams
 	 *  Ex: https://www.rts.ch/play/tv/rts-livestreams
 	 *  Ex: https://www.srf.ch/play/tv/sport-livestreams
+	 *  Ex: https://www.rsi.ch/play/tv/streaming
 	 */
-	if (pathname.endsWith("-livestreams")) {
+	if (pathname.endsWith("-livestreams") || pathname.endsWith("streaming")) {
 		// Returns livestreams homepage
 		return openPage(server, bu, "livestreams", null, null);
 	}

--- a/src/main/resources/deeplink/v2/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v2/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 40;
+var parsePlayUrlVersion = 41;
 var parsePlayUrlBuild = "mmf";
 
 if (!console) {
@@ -18,7 +18,7 @@ var hostnameMedia = "media";
 var hostnameMicropage = "micropage";
 var hostnameSearch = "search";
 var hostnameSection = "section";
-var hostnameShow = "show"; 
+var hostnameShow = "show";
 var hostnameTopic = "topic";
 
 function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor, supportedAppHostnames) {
@@ -445,8 +445,9 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor, suppor
 	 *  Ex: https://www.rtr.ch/play/tv/rtr-livestreams
 	 *  Ex: https://www.rts.ch/play/tv/rts-livestreams
 	 *  Ex: https://www.srf.ch/play/tv/sport-livestreams
+	 *  Ex: https://www.rsi.ch/play/tv/streaming
 	 */
-	if (pathname.endsWith("-livestreams")) {
+	if (pathname.endsWith("-livestreams") || pathname.endsWith("streaming")) {
 		// Returns livestreams homepage
 		return openLivestreamsHomePage(server, bu);
 	}


### PR DESCRIPTION
### Motivation and Context

>  RSI livestream tab has been added. Need to handle it in `parsePlayUrl.js` #93

### Description

> `https://www.rsi.ch/play/tv/streaming` is now parsed into:
> - `rsi://open?page=urn:rsi:page:livestreams&page-id=livestreams&server=production` (V1)
> - `playrsi://livestreams?server=production` (V2)

### Checklist

- [x] The branch has been rebased onto the `main` branch.
- [x] The green check mark "All checks have passed" is displayed on the PR.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
