### PR TITLE
Deeplink: add per channel TV guide urls

### DIFF
--- a/src/main/resources/deeplink/v1/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v1/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 41;
+var parsePlayUrlVersion = 42;
 var parsePlayUrlBuild = "mmf";
 
 if (!console) {
@@ -566,7 +566,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	}
 
 	/**
-	 *  Catch by date TV urls
+	 *  Catch old by date TV urls
 	 *
 	 *  Ex: https://www.rtr.ch/play/tv/emissiuns-tenor-data?date=07-03-2019
 	 */
@@ -587,13 +587,15 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	}
 
 	/**
-	 *  Catch new by date TV urls
+	 *  Catch new by date TV urls and TV program urls
 	 *
 	 *  Ex: https://www.rts.ch/play/tv/emissions-par-dates/2021-06-21
 	 *  Ex: https://www.srf.ch/play/tv/programm/2021-07-03
+	 *  Ex: https://www.rsi.ch/play/tv/guidatv-per-canale/la-2/2024-05-11?channelUrn=urn%3Arsi%3Achannel%3Atv%3Ala2
 	 */
 	if (pathname.includes("/tv/sendungen-nach-datum") || pathname.includes("/tv/emissions-par-dates") || pathname.includes("/tv/programmi-per-data") || pathname.includes("/tv/emissiuns-tenor-data") ||
-		pathname.includes("/tv/programm") || pathname.includes("/tv/programme") || pathname.includes("/tv/guida-programmi") || pathname.includes("/tv/program")) {
+		pathname.includes("/tv/programm") || pathname.includes("/tv/programme") || pathname.includes("/tv/guida-programmi") || pathname.includes("/tv/program") ||
+		pathname.includes("/tv/programm-nach-sender") || pathname.includes("/tv/programme-par-chaine") || pathname.includes("/tv/guidatv-per-canale") || pathname.includes("/tv/tenor-program-tv")) {
 		var lastPathComponent = pathname.split("/").slice(-1)[0];
 
 		var date = null;

--- a/src/main/resources/deeplink/v2/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v2/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 41;
+var parsePlayUrlVersion = 42;
 var parsePlayUrlBuild = "mmf";
 
 if (!console) {
@@ -553,7 +553,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor, suppor
 	}
 
 	/**
-	 *  Catch by date TV urls
+	 *  Catch old by date TV urls
 	 *
 	 *  Ex: https://www.rtr.ch/play/tv/emissiuns-tenor-data?date=07-03-2019
 	 */
@@ -577,9 +577,11 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor, suppor
 	 *
 	 *  Ex: https://www.rts.ch/play/tv/emissions-par-dates/2021-06-21
 	 *  Ex: https://www.srf.ch/play/tv/programm/2021-07-03
+	 *  Ex: https://www.rsi.ch/play/tv/guidatv-per-canale/la-2/2024-05-11?channelUrn=urn%3Arsi%3Achannel%3Atv%3Ala2
 	 */
 	if (pathname.includes("/tv/sendungen-nach-datum") || pathname.includes("/tv/emissions-par-dates") || pathname.includes("/tv/programmi-per-data") || pathname.includes("/tv/emissiuns-tenor-data") ||
-		pathname.includes("/tv/programm") || pathname.includes("/tv/programme") || pathname.includes("/tv/guida-programmi") || pathname.includes("/tv/program")) {
+		pathname.includes("/tv/programm") || pathname.includes("/tv/programme") || pathname.includes("/tv/guida-programmi") || pathname.includes("/tv/program") ||
+		pathname.includes("/tv/programm-nach-sender") || pathname.includes("/tv/programme-par-chaine") || pathname.includes("/tv/guidatv-per-canale") || pathname.includes("/tv/tenor-program-tv")) {
 		var lastPathComponent = pathname.split("/").slice(-1)[0];
 
 		var date = null;
@@ -1113,7 +1115,7 @@ function buildUri(scheme, host, path, queryParams) {
 	if (path) {
 		uri = uri + "/" + path;
 	}
-	if (queryParams && queryParams !== {}) {
+	if (queryParams && Object.keys(queryParams).length > 0) {
 		uri = uri + "?";
 		var optionIndex = 0;
 		for (var option in queryParams) {


### PR DESCRIPTION
### Motivation and Context

Deeplink report shared us that new Play RSI TV guide per channel urls are not decoded.

### Description

- Add TV guide per channel urls support for all BUs.
- Fix a javascript issue on `parsePlayUrl` script v2.

On MMF, unit tests are updated: https://github.com/SRGSSR/playsrg-mmf/compare/661da8e435f257ffeb7c93783983bb399eefebca...f26b9ce18aa55084e62dc7e4671bcebbc271584e

Test link: https://play-mmf.herokuapp.com/deeplink/index.html#playfff-pr-98

### Checklist

- [x] The branch has been rebased onto the `main` branch.
- [x] The green check mark "All checks have passed" is displayed on the PR.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
