### PR TITLE
PLAYNEXT-1827 - Media urn is case sensitive in redirect/detail link.

### DIFF
--- a/src/main/resources/deeplink/v1/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v1/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 43;
+var parsePlayUrlVersion = 44;
 var parsePlayUrlBuild = "mmf";
 
 if (!console) {
@@ -26,6 +26,9 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	if (slashCount > 2 && pathname.endsWith("/")) {
 		pathname = pathname.slice(0, -1)
 	}
+
+    hostnameCaseSensitive = hostname
+    pathnameCaseSensitive = pathname
 
 	// Case insensitive
 	hostname = hostname.toLowerCase();
@@ -262,7 +265,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	}
 
 	if (mediaType) {
-		var mediaId = pathname.split("/").slice(-1)[0];
+		var mediaId = pathnameCaseSensitive.split("/").slice(-1)[0];
 		if (mediaId) {
 			var startTime = queryParams["startTime"];
 			return openMedia(server, bu, mediaType, mediaId, startTime);

--- a/src/main/resources/deeplink/v1/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v1/parsePlayUrl.js
@@ -27,8 +27,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 		pathname = pathname.slice(0, -1)
 	}
 
-    hostnameCaseSensitive = hostname
-    pathnameCaseSensitive = pathname
+    originalPathname = pathname
 
 	// Case insensitive
 	hostname = hostname.toLowerCase();
@@ -265,7 +264,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	}
 
 	if (mediaType) {
-		var mediaId = pathnameCaseSensitive.split("/").slice(-1)[0];
+		var mediaId = originalPathname.split("/").slice(-1)[0];
 		if (mediaId) {
 			var startTime = queryParams["startTime"];
 			return openMedia(server, bu, mediaType, mediaId, startTime);

--- a/src/main/resources/deeplink/v2/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v2/parsePlayUrl.js
@@ -44,8 +44,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor, suppor
 		pathname = pathname.slice(0, -1)
 	}
 
-    hostnameCaseSensitive = hostname
-    pathnameCaseSensitive = pathname
+    originalPathname = pathname
 
 	// Case insensitive
 	hostname = hostname.toLowerCase();
@@ -258,7 +257,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor, suppor
 	}
 
 	if (mediaType) {
-		var mediaId = pathnameCaseSensitive.split("/").slice(-1)[0];
+		var mediaId = originalPathname.split("/").slice(-1)[0];
 		if (mediaId) {
 			var startTime = queryParams["startTime"];
 			return openMedia(server, bu, mediaType, mediaId, startTime);

--- a/src/main/resources/deeplink/v2/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v2/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 43;
+var parsePlayUrlVersion = 44;
 var parsePlayUrlBuild = "mmf";
 
 if (!console) {
@@ -43,6 +43,9 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor, suppor
 	if (slashCount > 2 && pathname.endsWith("/")) {
 		pathname = pathname.slice(0, -1)
 	}
+
+    hostnameCaseSensitive = hostname
+    pathnameCaseSensitive = pathname
 
 	// Case insensitive
 	hostname = hostname.toLowerCase();
@@ -255,7 +258,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor, suppor
 	}
 
 	if (mediaType) {
-		var mediaId = pathname.split("/").slice(-1)[0];
+		var mediaId = pathnameCaseSensitive.split("/").slice(-1)[0];
 		if (mediaId) {
 			var startTime = queryParams["startTime"];
 			return openMedia(server, bu, mediaType, mediaId, startTime);


### PR DESCRIPTION
### Motivation and Context

Fix Issue: #109 

Live urn urn for RSI are case sensitive. The share link return by parsePlayUrl.js was ignoring the case causing unreadable content in the app for RSI links.

ex : Rete Uno - https://www.rsi.ch/play/radio/redirect/detail/livestream_ReteUno is returning `playrsi://media/urn:rsi:audio:livestream_reteuno` instead of `playrsi://media/urn:rsi:audio:livestream_ReteUno`

### Description

Use pathname with case sensitive for the media URL in `/tv/redirect/detail/` links.

https://github.com/SRGSSR/playsrg-mmf/compare/7ea57713c6a1981f5d7ad071549c964fe7fd01a5..fb67abfe0226c2b0153d6339b5f816548fb3fbb9

### Checklist

- [x] The branch has been rebased onto the `main` branch.
- [x] The green check mark "All checks have passed" is displayed on the PR.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
