### PR TITLE
fix(recommendation-controller): missing access control allow origin

### DIFF
--- a/src/main/java/ch/srgssr/playfff/controller/RecommendationController.java
+++ b/src/main/java/ch/srgssr/playfff/controller/RecommendationController.java
@@ -43,6 +43,7 @@ public class RecommendationController {
         }
     }
 
+    @CrossOrigin
     @RequestMapping({"/api/v2/playlist/recommendation/{purpose}/{urn}", "/api/v2/playlist/recommendation/{purpose}/{urn}.json"})
     @ResponseBody
     RecommendedList recommendationV2(


### PR DESCRIPTION
### Motivation and Context

Add HTTP header allowing browsers to consume the API.

### Description

- add `@CrossOrigin` annotation to `recommendation` call

### Checklist

- [ ] The branch has been rebased onto the `main` branch.
- [ ] The green check mark "All checks have passed" is displayed on the PR.
- [ ] The documentation has been updated (if relevant).
- [ ] Issues are linked to the PR, if any.
