### PR TITLE
Deeplink: add media urn redirect support

### DIFF
--- a/src/main/resources/deeplink/v1/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v1/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 44;
+var parsePlayUrlVersion = 45;
 var parsePlayUrlBuild = "mmf";
 
 if (!console) {
@@ -253,6 +253,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	 *  Ex: https://www.rts.ch/play/tv/redirect/detail/9938530
 	 *  Ex: https://www.srf.ch/play/tv/redirect/Detail/99f040e9-b1e6-4d7a-bc08-d5639d600aa1
 	 *  Ex: https://www.srf.ch/play/tv/redirect/detail/99f040e9-b1e6-4d7a-bc08-d5639d600aa1/
+	 *  Ex: https://www.srf.ch/play/tv/redirect/detail/urn:srf:video:96705d59-c9d5-40c2-99c1-89ef5756ef24
 	 */
 	switch (true) {
 		case pathname.includes("/tv/redirect/detail/"):
@@ -264,10 +265,13 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor) {
 	}
 
 	if (mediaType) {
-		var mediaId = originalPathname.split("/").slice(-1)[0];
-		if (mediaId) {
-			var startTime = queryParams["startTime"];
-			return openMedia(server, bu, mediaType, mediaId, startTime);
+		var mediaIdentifier = originalPathname.split("/").slice(-1)[0];
+		var startTime = queryParams["startTime"];
+		if (mediaIdentifier.startsWith("urn:")) {
+			return openMediaUrn(server, bu, mediaIdentifier, startTime);
+		}
+		else if (mediaIdentifier) {
+			return openMedia(server, bu, mediaType, mediaIdentifier, startTime);
 		}
 		else {
 			mediaType = null;

--- a/src/main/resources/deeplink/v2/parsePlayUrl.js
+++ b/src/main/resources/deeplink/v2/parsePlayUrl.js
@@ -1,6 +1,6 @@
 // parsePlayUrl
 
-var parsePlayUrlVersion = 44;
+var parsePlayUrlVersion = 45;
 var parsePlayUrlBuild = "mmf";
 
 if (!console) {
@@ -246,6 +246,7 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor, suppor
 	 *  Ex: https://www.rts.ch/play/tv/redirect/detail/9938530
 	 *  Ex: https://www.srf.ch/play/tv/redirect/Detail/99f040e9-b1e6-4d7a-bc08-d5639d600aa1
 	 *  Ex: https://www.srf.ch/play/tv/redirect/detail/99f040e9-b1e6-4d7a-bc08-d5639d600aa1/
+	 *  Ex: https://www.srf.ch/play/tv/redirect/detail/urn:srf:video:96705d59-c9d5-40c2-99c1-89ef5756ef24
 	 */
 	switch (true) {
 		case pathname.includes("/tv/redirect/detail/"):
@@ -257,10 +258,13 @@ function parseForPlayApp(scheme, hostname, pathname, queryParams, anchor, suppor
 	}
 
 	if (mediaType) {
-		var mediaId = originalPathname.split("/").slice(-1)[0];
-		if (mediaId) {
-			var startTime = queryParams["startTime"];
-			return openMedia(server, bu, mediaType, mediaId, startTime);
+		var mediaIdentifier = originalPathname.split("/").slice(-1)[0];
+		var startTime = queryParams["startTime"];
+		if (mediaIdentifier.startsWith("urn:")) {
+			return openMediaUrn(server, bu, mediaIdentifier, startTime);
+		}
+		else if (mediaIdentifier) {
+			return openMedia(server, bu, mediaType, mediaIdentifier, startTime);
 		}
 		else {
 			mediaType = null;


### PR DESCRIPTION
### Motivation and Context

https://srgssr-ch.atlassian.net/wiki/spaces/SRGPLAY/pages/799082745/URL+Shortening

After reading the Play web shorten urls documentation, a new redirect detail url has bee found.

https://play-mmf.herokuapp.com/deeplink/index.html
The Play MMF deeplink tool failed and in apps, an error appeared.

This PR proposes to add the support.

### Description

Add missing media urn redirect support in JS deeplink files.

UTs updated here: https://github.com/SRGSSR/playsrg-mmf/commit/e47cac0138a83e3d3c10a364447fb588bc4d5dfb

### Checklist

- [x] The branch has been rebased onto the `main` branch.
- [x] The green check mark "All checks have passed" is displayed on the PR.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
